### PR TITLE
Load setting schema files using jsonref

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -252,7 +252,7 @@
 
     "properties": {
         "version": {
-            "type": "number",
+            "type": "string",
             "title": "Analysis settings schema version",
             "description": "The schema version for analysis settings validation (optional)",
             "minimum": 3

--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -5,7 +5,7 @@
    "additionalProperties":false,
    "properties":{
       "version": {
-          "type": "number",
+          "type": "string",
           "title": "Model settings schema version",
           "description": "The schema version for model settings validation (optional)",
           "minimum": 3

--- a/ods_tools/oed/setting_schema.py
+++ b/ods_tools/oed/setting_schema.py
@@ -1,5 +1,6 @@
 import json
 import jsonschema
+import jsonref
 import logging
 import os
 
@@ -92,7 +93,7 @@ class SettingSchema:
         """
         filepath = Path(setting_json)
         with filepath.open(encoding="UTF-8") as f:
-            schema = json.load(f)
+            schema = jsonref.load(f)
             return cls(schema, setting_json)
 
     def _remap_key(self, obj, key_new, key_old):

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 pandas
 chardet
 jsonschema
+jsonref


### PR DESCRIPTION
<!--start_release_notes-->
### Load setting schema files using jsonref
* Fix #12 load settings file now return data using [jsonref](https://github.com/gazpachoking/jsonref) which automatic de-references [JSON Reference](https://datatracker.ietf.org/doc/html/draft-pbryan-zyp-json-ref-03) objects
* Switched settings `version` field type to string 
<!--end_release_notes-->
