### PR TITLE
detect stream_obj type if not set

### DIFF
--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -94,6 +94,7 @@ def detect_stream_type(stream_obj):
     """
     type_map = {
         'csv': [
+            'csv',
             '.csv',
             'text/csv',
             'application/gzip',
@@ -102,6 +103,7 @@ def detect_stream_type(stream_obj):
             'application/x-bzip2',
         ],
         'parquet': [
+            'parquet',
             '.parquet',
             'application/octet-stream',
         ]
@@ -124,7 +126,7 @@ def detect_stream_type(stream_obj):
     # detect by content_type
     if isinstance(content_type, str):
         for filetype in type_map:
-            if content_type in type_map[filetype]:
+            if content_type.lower() in type_map[filetype]:
                 return filetype
 
     # Format unknown

--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import mimetypes
 
 import pandas as pd
 import numpy as np
@@ -74,6 +75,60 @@ def detect_encoding(filepath):
     detector.close()
     return detector.result
 
+def detect_stream_type(stream_obj):
+    """
+    Given a file object try to inferr if its holding 
+    `csv` or `parquet` data from its attributes 
+    If unknown return ""
+
+    Note: content types matching compressed formats 
+     'gzip', 'x-bzip2', 'zip' and 'x-bzip2'
+     are assumed to be compressed csv
+
+    Args:
+        stream_obj: object with a read() method
+
+    Returns:
+        stream_type (str): 'csv', 'parquet' or ''
+    """
+    type_map = {
+        'csv': [
+            '.csv',
+            'text/csv',
+            'application/gzip',
+            'application/x-bzip2',
+            'application/zip',
+            'application/x-bzip2',
+        ],
+        'parquet': [
+            '.parquet',
+            'application/octet-stream',
+        ]
+    }    
+    filename = getattr(stream_obj, 'name', None)
+    content_type = getattr(stream_obj, 'content_type', None)
+
+    # detect by filename
+    if isinstance(filename, str):
+        extention = Path(filename).suffix.lower()
+        mimetype = mimetypes.MimeTypes().guess_type(filename)[0]
+        for filetype in type_map:
+            # check by extention exact match 
+            if extention in type_map[filetype]:
+                return filetype
+            # check by mimetype match 
+            if mimetype in type_map[filetype]:
+                return filetype
+
+    # detect by content_type 
+    if isinstance(content_type, str):
+        for filetype in type_map:
+            if content_type in type_map[filetype]:
+                return filetype
+
+    # Format unknown 
+    return 'unknown'
+    
 
 def is_readable(obj):
     return hasattr(obj, 'read') and callable(getattr(obj, 'read'))
@@ -193,7 +248,7 @@ class OedSource:
         return cls(exposure, oed_type, 'orig', {'orig': {'source_type': 'filepath', 'filepath': filepath, 'read_param': read_param}})
 
     @classmethod
-    def from_stream_obj(cls, exposure, oed_type, stream_obj, format='csv', read_param=None):
+    def from_stream_obj(cls, exposure, oed_type, stream_obj, format=None, read_param=None):
         """
         OedSource Constructor from a filepath
         Args:
@@ -207,6 +262,10 @@ class OedSource:
         if read_param is None:
             read_param = {}
         oed_source = cls(exposure, oed_type, 'orig', {'orig': {'source_type': 'stream', 'format': format}})
+
+        if not format:
+            format = detect_stream_type(stream_obj)
+
         if format == 'csv':
             oed_df = pd.read_csv(stream_obj, **read_param)
             ods_fields = exposure.get_input_fields(oed_type)

--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -75,6 +75,7 @@ def detect_encoding(filepath):
     detector.close()
     return detector.result
 
+
 def detect_stream_type(stream_obj):
     """
     Given a file object try to inferr if its holding 
@@ -89,7 +90,7 @@ def detect_stream_type(stream_obj):
         stream_obj: object with a read() method
 
     Returns:
-        stream_type (str): 'csv', 'parquet' or ''
+        stream_type (str): 'csv', 'parquet' or 'unknown'
     """
     type_map = {
         'csv': [
@@ -104,7 +105,7 @@ def detect_stream_type(stream_obj):
             '.parquet',
             'application/octet-stream',
         ]
-    }    
+    }
     filename = getattr(stream_obj, 'name', None)
     content_type = getattr(stream_obj, 'content_type', None)
 
@@ -113,22 +114,22 @@ def detect_stream_type(stream_obj):
         extention = Path(filename).suffix.lower()
         mimetype = mimetypes.MimeTypes().guess_type(filename)[0]
         for filetype in type_map:
-            # check by extention exact match 
+            # check by extention exact match
             if extention in type_map[filetype]:
                 return filetype
-            # check by mimetype match 
+            # check by mimetype match
             if mimetype in type_map[filetype]:
                 return filetype
 
-    # detect by content_type 
+    # detect by content_type
     if isinstance(content_type, str):
         for filetype in type_map:
             if content_type in type_map[filetype]:
                 return filetype
 
-    # Format unknown 
+    # Format unknown
     return 'unknown'
-    
+
 
 def is_readable(obj):
     return hasattr(obj, 'read') and callable(getattr(obj, 'read'))

--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -4,7 +4,6 @@ import mimetypes
 import pandas as pd
 import numpy as np
 from chardet.universaldetector import UniversalDetector
-from pandas.errors import ParserError
 
 from .common import OED_TYPE_TO_NAME, OdsException, PANDAS_COMPRESSION_MAP, PANDAS_DEFAULT_NULL_VALUES, is_relative, BLANK_VALUES
 from .forex import convert_currency
@@ -284,8 +283,8 @@ class OedSource:
                 oed_df = pd.read_parquet(stream_obj, **read_param)
             else:
                 raise OdsException(f'Unsupported stream format {format}')
-        except ParserError as e:
-            raise OdsException(f'Failed to read stream data, either unsupported type or data error') from e
+        except Exception as e:
+            raise OdsException(f'Failed to read stream data') from e
 
         oed_source.dataframe = oed_df
         oed_source.loaded = True

--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -284,7 +284,7 @@ class OedSource:
             else:
                 raise OdsException(f'Unsupported stream format {format}')
         except Exception as e:
-            raise OdsException(f'Failed to read stream data') from e
+            raise OdsException('Failed to read stream data') from e
 
         oed_source.dataframe = oed_df
         oed_source.loaded = True

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -17,7 +17,6 @@ sys.path.append(sys.path.pop(0))
 
 from ods_tools.main import convert
 from ods_tools.oed import OedExposure, OedSchema, OdsException, ModelSettingSchema, AnalysisSettingSchema
-from ods_tools.oed.source import detect_stream_type
 from ods_tools.oed.common import OdsException
 
 base_test_path = pathlib.Path(__file__).parent
@@ -156,9 +155,6 @@ class OdsPackageTests(TestCase):
 
             csv_loc_obj = open(os.path.join(tmp_run_dir, 'SourceLocOEDPiWind.csv'))
             parquet_acc_obj = open(os.path.join(tmp_run_dir, 'SourceAccOEDPiWind.parquet'), 'rb')
-
-            self.assertEqual(detect_stream_type(csv_loc_obj), 'csv')
-            self.assertEqual(detect_stream_type(parquet_acc_obj), 'parquet')
 
             config = {
                 'location': csv_loc_obj,

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -154,7 +154,6 @@ class OdsPackageTests(TestCase):
             with open(os.path.join(tmp_run_dir, 'SourceAccOEDPiWind.parquet'), 'wb') as acc_parquet:
                 acc_parquet.write(urllib.request.urlopen(base_url + '/SourceAccOEDPiWind.parquet').read())
 
-
             csv_loc_obj = open(os.path.join(tmp_run_dir, 'SourceLocOEDPiWind.csv'))
             parquet_acc_obj = open(os.path.join(tmp_run_dir, 'SourceAccOEDPiWind.parquet'), 'rb')
 
@@ -173,7 +172,7 @@ class OdsPackageTests(TestCase):
             account = exposure.account.dataframe
             self.assertTrue(isinstance(location, pd.DataFrame))
             self.assertTrue(isinstance(account, pd.DataFrame))
-    
+
     def test_load_oed_from_stream__invalid_types(self):
         with tempfile.TemporaryDirectory() as tmp_run_dir:
 
@@ -190,7 +189,6 @@ class OdsPackageTests(TestCase):
                 exposure = OedExposure(**{'location': csv_as_parquet})
             with self.assertRaises(OdsException) as ex:
                 exposure = OedExposure(**{'account': parquet_as_csv})
-
 
     def test_reporting_currency(self):
         config = {


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Detect object type if not set
Use the Stream object attributes to try and detected the data type stored. (csv, parquet, compressed, or csv) 
<!--end_release_notes-->
