### PR TITLE
only check non BLANK value in peril, occupancy, and construction code validation

### DIFF
--- a/ods_tools/oed/validator.py
+++ b/ods_tools/oed/validator.py
@@ -193,7 +193,9 @@ class Validator:
             for column in oed_source.dataframe.columns.intersection(set(OED_PERIL_COLUMNS)):
                 peril_values = oed_source.dataframe[column].str.split(';').apply(pd.Series, 1).stack()
                 invalid_perils = oed_source.dataframe.iloc[
-                    peril_values[~peril_values.isin(self.exposure.oed_schema.schema['perils']['info'])].index.droplevel(-1)]
+                    peril_values[~peril_values.isin(
+                        set(self.exposure.oed_schema.schema['perils']['info']) | BLANK_VALUES
+                    )].index.droplevel(-1)]
                 if not invalid_perils.empty:
                     invalid_data.append({'name': oed_source.oed_name, 'source': oed_source.current_source,
                                          'msg': f"{column} has invalid perils.\n"
@@ -212,8 +214,8 @@ class Validator:
             if occupancy_code_column is None:
                 continue
             identifier_field = self.identifier_field_maps[oed_source]
-            invalid_occupancy_code = oed_source.dataframe[
-                ~oed_source.dataframe[occupancy_code_column].astype(str).isin(self.exposure.oed_schema.schema['occupancy'])]
+            invalid_occupancy_code = oed_source.dataframe[~oed_source.dataframe[occupancy_code_column].astype(str).isin(
+                set(self.exposure.oed_schema.schema['occupancy']) | BLANK_VALUES)]
             if not invalid_occupancy_code.empty:
                 invalid_data.append({'name': oed_source.oed_name, 'source': oed_source.current_source,
                                      'msg': f"invalid OccupancyCode.\n"
@@ -232,8 +234,8 @@ class Validator:
             if construction_code_column is None:
                 continue
             identifier_field = self.identifier_field_maps[oed_source]
-            invalid_construction_code = oed_source.dataframe[
-                ~oed_source.dataframe[construction_code_column].astype(str).isin(self.exposure.oed_schema.schema['construction'])]
+            invalid_construction_code = oed_source.dataframe[~oed_source.dataframe[construction_code_column].astype(str).isin(
+                set(self.exposure.oed_schema.schema['construction']) | BLANK_VALUES)]
             if not invalid_construction_code.empty:
                 invalid_data.append({'name': oed_source.oed_name, 'source': oed_source.current_source,
                                      'msg': f"invalid ConstructionCode.\n"


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix: ignore blank value in  peril, occupancy, and construction code validation
<!--end_release_notes-->
