### PR TITLE
use the package logger instead of __name__ logger to setup handler and log level in main

### DIFF
--- a/ods_tools/__init__.py
+++ b/ods_tools/__init__.py
@@ -3,4 +3,3 @@ __version__ = '3.0.5'
 import logging
 
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())

--- a/ods_tools/main.py
+++ b/ods_tools/main.py
@@ -10,9 +10,8 @@ __all__ = [
 import argparse
 import logging
 
-from .oed import OedExposure, OdsException
-
-logger = logging.getLogger(__name__)
+from ods_tools.oed import OedExposure, OdsException
+from ods_tools import logger
 
 
 def get_oed_exposure(config_json=None, oed_dir=None, **kwargs):

--- a/ods_tools/oed/validator.py
+++ b/ods_tools/oed/validator.py
@@ -85,7 +85,7 @@ class Validator:
             return f"in {_data['name']} {_data['source']}\n {_data['msg']}"
 
         for invalid_data in log_msg:
-            logger.info(invalid_data_to_str(invalid_data))
+            logger.warning(invalid_data_to_str(invalid_data))
         if raise_msg:
             raise OdsException('\n'.join(invalid_data_to_str(invalid_data) for invalid_data in raise_msg))
         return return_msg


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix: setup the correct logger in the main module
in the main.py module the logger selected to be setup was ods_tools.main.
therefore none of the logger call in ods_tools.oed are inheriting from it.
change to use ods_tools logger instead

<!--end_release_notes-->
