### PR TITLE
ignore extra blank in column name, raise error for invalid column name

### DIFF
--- a/ods_tools/oed/common.py
+++ b/ods_tools/oed/common.py
@@ -81,7 +81,7 @@ VALIDATOR_ON_ERROR_ACTION = {'raise', 'log', 'ignore', 'return'}
 DEFAULT_VALIDATION_CONFIG = [
     {'name': 'source_coherence', 'on_error': 'raise'},
     {'name': 'required_fields', 'on_error': 'raise'},
-    {'name': 'unknown_column', 'on_error': 'log'},
+    {'name': 'unknown_column', 'on_error': 'raise'},
     {'name': 'valid_values', 'on_error': 'raise'},
     {'name': 'perils', 'on_error': 'raise'},
     {'name': 'occupancy_code', 'on_error': 'raise'},

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -77,6 +77,17 @@ class OedSchema:
             return cls(schema, oed_json)
 
     @staticmethod
+    def to_universal_field_name(column: str):
+        """
+        transform column name into string that can be matched directly with the schema field name
+        Args:
+            column (str): name of the column
+        :return:
+            str
+        """
+        return column.strip().lower()
+
+    @staticmethod
     def column_to_field(columns: list, oed_fields: dict, use_generic_flexi=True):
         """
         map column to OED field
@@ -90,17 +101,17 @@ class OedSchema:
             dict mapping between exact OED column name and field name in oed_schema
         """
         # support for name different from standard OED column name
-        aliases = {field_info.get('alias').lower(): field_name for field_name, field_info in oed_fields.items() if field_info.get('alias')}
+        aliases = {OedSchema.to_universal_field_name(field_info.get('alias')): field_name for field_name, field_info in oed_fields.items() if field_info.get('alias')}
         result = {}
         for column in columns:
-            if column.lower() in oed_fields:
-                result[column] = oed_fields[column.lower()]
-            elif column.lower() in aliases:
-                result[column] = oed_fields[aliases[column.lower()]]
+            if OedSchema.to_universal_field_name(column) in oed_fields:
+                result[column] = oed_fields[OedSchema.to_universal_field_name(column)]
+            elif OedSchema.to_universal_field_name(column) in aliases:
+                result[column] = oed_fields[aliases[OedSchema.to_universal_field_name(column)]]
             else:
                 for field_suffix in ['xx', 'zzz']:
-                    for i in range(1, len(column)):
-                        field_name = column.lower()[:-i] + field_suffix
+                    for i in range(1, len(OedSchema.to_universal_field_name(column))):
+                        field_name = OedSchema.to_universal_field_name(column)[:-i] + field_suffix
                         if field_name in oed_fields:
                             if use_generic_flexi:
                                 result[column] = oed_fields[field_name]

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -101,7 +101,8 @@ class OedSchema:
             dict mapping between exact OED column name and field name in oed_schema
         """
         # support for name different from standard OED column name
-        aliases = {OedSchema.to_universal_field_name(field_info.get('alias')): field_name for field_name, field_info in oed_fields.items() if field_info.get('alias')}
+        aliases = {OedSchema.to_universal_field_name(field_info.get('alias')): field_name for field_name,
+                   field_info in oed_fields.items() if field_info.get('alias')}
         result = {}
         for column in columns:
             if OedSchema.to_universal_field_name(column) in oed_fields:

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -109,7 +109,7 @@ class OdsPackageTests(TestCase):
             'AccNumber': [1, 2],
             'AccName': [1, np.nan],
             'LocNumber': [1, 2],
-            'CountryCode': ['GB', 'FR'],
+            'COUNTRYCODE ': ['GB', 'FR'],
             'LocPerilsCovered': 'WTC',
             'buildingtiv': ['1000', '20000'],
             'ContentsTIV': [0, 0],
@@ -128,6 +128,9 @@ class OdsPackageTests(TestCase):
 
         # check BuildingTIV converted to float and use field case
         self.assertTrue(pd.api.types.is_numeric_dtype(exposure.location.dataframe['BuildingTIV']))
+
+        # check case and extra space are ignored
+        self.assertTrue(exposure.location.dataframe['CountryCode'][0] == 'GB')
 
     def test_load_oed_from_stream(self):
         with tempfile.TemporaryDirectory() as tmp_run_dir:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Ignore blank character at the beginning and end of column name
Often exposure data are presented with extra blank character at the beginning or end of column name creating error if the column is required or silently ignoring the issue which could lead to invalid result.
This PR will strip the column name of extra blank to match correctly with OED field name.
It will also raise an error instead of simply logging the issue if a column is not recognized.

<!--end_release_notes-->
