### PR TITLE
Replace hardcoded packages, with find_packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setuptools.setup(
     },
     author='Oasis LMF',
     author_email="support@oasislmf.org",
-    packages=setuptools.find_packages(exclude=('tests', 'tests.*', 'tests.*.*'))
+    packages=setuptools.find_packages(exclude=('tests', 'tests.*', 'tests.*.*')),
     package_dir={'ods_tools': 'ods_tools'},
     python_requires='>=3.7',
     install_requires=reqs,

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setuptools.setup(
     },
     author='Oasis LMF',
     author_email="support@oasislmf.org",
-    packages=['ods_tools', 'ods_tools.oed', 'ods_tools.data'],
+    packages=setuptools.find_packages(exclude=('tests', 'tests.*', 'tests.*.*'))
     package_dir={'ods_tools': 'ods_tools'},
     python_requires='>=3.7',
     install_requires=reqs,


### PR DESCRIPTION
<!--start_release_notes-->
### Updated setup.py to use find_packages
* Dynamically build all sub-dirs of `ods_tools` into pip package

<!--end_release_notes-->

**Note:** this PR is needed for https://github.com/OasisLMF/ODS_Tools/pull/37
```
In [y]: setuptools.find_packages(exclude=('tests', 'tests.*', 'tests.*.*'))
Out[y]: 
['ods_tools',
 'ods_tools.oed',
 'ods_tools.oed.required_fields',
 'ods_tools.oed.required_fields.enums']
```