### PR TITLE
support empty OedSource

### DIFF
--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import mimetypes
 
+import logging
 import pandas as pd
 import numpy as np
 from chardet.universaldetector import UniversalDetector
@@ -8,6 +9,8 @@ from chardet.universaldetector import UniversalDetector
 from .common import OED_TYPE_TO_NAME, OdsException, PANDAS_COMPRESSION_MAP, PANDAS_DEFAULT_NULL_VALUES, is_relative, BLANK_VALUES, fill_empty
 from .forex import convert_currency
 from .oed_schema import OedSchema
+
+logger = logging.getLogger(__file__)
 
 try:
     from functools import cached_property
@@ -155,7 +158,7 @@ class OedSource:
         self.oed_name = OED_TYPE_TO_NAME[oed_type]
         self.cur_version_name = cur_version_name
         self.sources = sources
-        self.loaded = False
+        self._loaded = False
 
     def __str__(self):
         """
@@ -172,6 +175,16 @@ class OedSource:
             info dict
         """
         return {'cur_version_name': self.cur_version_name, 'sources': self.sources}
+
+    @property
+    def loaded(self):
+        return self._loaded
+
+    @loaded.setter
+    def loaded(self, is_loaded):
+        if is_loaded and self.dataframe.empty:
+            logger.info(f'{self.oed_name} {self} is empty')
+        self._loaded = is_loaded
 
     @classmethod
     def from_oed_info(cls, exposure, oed_type: str, oed_info, **kwargs):

--- a/ods_tools/oed/validator.py
+++ b/ods_tools/oed/validator.py
@@ -190,6 +190,8 @@ class Validator:
         invalid_data = []
         for oed_source in self.exposure.get_oed_sources():
             identifier_field = self.identifier_field_maps[oed_source]
+            if oed_source.dataframe.empty:
+                continue
             for column in oed_source.dataframe.columns.intersection(set(OED_PERIL_COLUMNS)):
                 peril_values = oed_source.dataframe[column].str.split(';').apply(pd.Series, 1).stack()
                 invalid_perils = oed_source.dataframe.iloc[


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Support Empty OedSource
fix issue raising error when OedSource was empty.
when an OedSource is empty, log an info level message.
<!--end_release_notes-->
