### PR TITLE
add option to manage unknown column when saving files

### DIFF
--- a/ods_tools/oed/__init__.py
+++ b/ods_tools/oed/__init__.py
@@ -12,5 +12,6 @@ from .common import (
 __all__ = [
     'OedExposure', 'OedSchema', 'OedSource', 'ModelSettingSchema', 'AnalysisSettingSchema',
     'OdsException', 'PANDAS_COMPRESSION_MAP', 'PANDAS_DEFAULT_NULL_VALUES', 'USUAL_FILE_NAME', 'OED_TYPE_TO_NAME',
-    'OED_NAME_TO_TYPE', 'OED_IDENTIFIER_FIELDS', 'VALIDATOR_ON_ERROR_ACTION', 'DEFAULT_VALIDATION_CONFIG', 'OED_PERIL_COLUMNS', 'fill_empty'
+    'OED_NAME_TO_TYPE', 'OED_IDENTIFIER_FIELDS', 'VALIDATOR_ON_ERROR_ACTION', 'DEFAULT_VALIDATION_CONFIG', 'OED_PERIL_COLUMNS', 'fill_empty',
+    'UnknownColumnSaveOption'
 ]

--- a/ods_tools/oed/__init__.py
+++ b/ods_tools/oed/__init__.py
@@ -4,7 +4,8 @@ from .setting_schema import ModelSettingSchema, AnalysisSettingSchema
 from .source import OedSource
 from .common import (
     OdsException, PANDAS_COMPRESSION_MAP, PANDAS_DEFAULT_NULL_VALUES, USUAL_FILE_NAME, OED_TYPE_TO_NAME,
-    OED_NAME_TO_TYPE, OED_IDENTIFIER_FIELDS, VALIDATOR_ON_ERROR_ACTION, DEFAULT_VALIDATION_CONFIG, OED_PERIL_COLUMNS, fill_empty
+    OED_NAME_TO_TYPE, OED_IDENTIFIER_FIELDS, VALIDATOR_ON_ERROR_ACTION, DEFAULT_VALIDATION_CONFIG, OED_PERIL_COLUMNS, fill_empty,
+    UnknownColumnSaveOption
 )
 
 

--- a/ods_tools/oed/common.py
+++ b/ods_tools/oed/common.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 from pathlib import Path
 import numpy as np
 import pandas as pd
+from enum import Enum
 
 
 class OdsException(Exception):
@@ -103,3 +104,9 @@ def fill_empty(df, columns, value):
         if df[column].dtypes.name == 'category' and value not in {None, np.nan}.union(df[column].cat.categories):
             df[column] = df[column].cat.add_categories(value)
         df.loc[df[column].isin(BLANK_VALUES), column] = value
+
+
+class UnknownColumnSaveOption(Enum):
+    IGNORE = 1
+    RENAME = 2
+    DELETE = 3

--- a/ods_tools/oed/exposure.py
+++ b/ods_tools/oed/exposure.py
@@ -9,7 +9,8 @@ import json
 from pathlib import Path
 
 from .common import (PANDAS_COMPRESSION_MAP,
-                     USUAL_FILE_NAME, OED_TYPE_TO_NAME)
+                     USUAL_FILE_NAME, OED_TYPE_TO_NAME,
+                     UnknownColumnSaveOption)
 from .oed_schema import OedSchema
 from .source import OedSource
 from .validator import Validator
@@ -165,7 +166,7 @@ class OedExposure:
         with open(filepath, 'w') as info_file:
             json.dump(self.info, info_file, indent='  ', default=str)
 
-    def save(self, path, version_name=None, compression=None, save_config=False):
+    def save(self, path, version_name=None, compression=None, save_config=False, unknown_columns=UnknownColumnSaveOption.IGNORE):
         """
         helper function to save all OED data to a location with specific compression
         Args:
@@ -205,7 +206,8 @@ class OedExposure:
             filepath = filepath.with_suffix(PANDAS_COMPRESSION_MAP[compression])
 
             oed_source.save(saved_version_name + '_' + f'{compression}',
-                            {'source_type': 'filepath', 'filepath': filepath, 'extension': compression})
+                            {'source_type': 'filepath', 'filepath': filepath, 'extension': compression},
+                            unknown_columns=unknown_columns)
         if save_config:
             self.save_config(Path(path, self.DEFAULT_EXPOSURE_CONFIG_NAME))
 

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -444,8 +444,7 @@ class OdsPackageTests(TestCase):
                 'ToDelete': [3, 4],
                 'ToIgnore': [5, 6],
                 'default_rename': [7, 8],
-                }
-            )
+            })
             oed = OedExposure(**{'location': df})
             save_option = {
                 'ToRename': UnknownColumnSaveOption.RENAME,
@@ -461,7 +460,6 @@ class OdsPackageTests(TestCase):
             assert 'FlexiLocToRename' in oed_saved.location.dataframe.columns
             assert 'ToDelete' not in oed_saved.location.dataframe.columns
             assert 'FlexiLocdefault_rename' in oed_saved.location.dataframe.columns
-
 
     def test_setting_schema_analysis__is_valid(self):
         file_name = 'analysis_settings.json'

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -18,8 +18,7 @@ import tempfile
 sys.path.append(sys.path.pop(0))
 
 from ods_tools.main import convert
-from ods_tools.oed import OedExposure, OedSchema, OdsException, ModelSettingSchema, AnalysisSettingSchema
-from ods_tools.oed.common import OED_TYPE_TO_NAME
+from ods_tools.oed import OedExposure, OedSchema, OdsException, ModelSettingSchema, AnalysisSettingSchema, OED_TYPE_TO_NAME, UnknownColumnSaveOption
 
 logger = logging.getLogger(__file__)
 
@@ -428,6 +427,41 @@ class OdsPackageTests(TestCase):
                 'LocCurrency': ['GBP', 'EUR']}).to_csv(loc_path)
             oed = OedExposure(**{'location': loc_path})
             assert oed.location.dataframe['CountryCode'][0] == 'NA'
+
+    def test_unknown_column_management(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            loc_path = pathlib.Path(tmp_dir, 'location.csv')
+            df = pd.DataFrame({
+                'PortNumber': [1, 1],
+                'AccNumber': [1, 2],
+                'LocNumber': [1, 2],
+                'CountryCode': ['NA', 'FR'],
+                'LocPerilsCovered': 'WTC',
+                'BuildingTIV': ['1000', '20000'],
+                'ContentsTIV': [0, 0],
+                'LocCurrency': ['GBP', 'EUR'],
+                'ToRename': [1, 2],
+                'ToDelete': [3, 4],
+                'ToIgnore': [5, 6],
+                'default_rename': [7, 8],
+                }
+            )
+            oed = OedExposure(**{'location': df})
+            save_option = {
+                'ToRename': UnknownColumnSaveOption.RENAME,
+                'ToDelete': UnknownColumnSaveOption.DELETE,
+                'ToIgnore': UnknownColumnSaveOption.IGNORE,
+                'default': UnknownColumnSaveOption.RENAME,
+            }
+
+            oed.save(tmp_dir, unknown_columns=save_option)
+            oed_saved = OedExposure(**{'location': loc_path})
+
+            assert 'ToIgnore' in oed_saved.location.dataframe.columns
+            assert 'FlexiLocToRename' in oed_saved.location.dataframe.columns
+            assert 'ToDelete' not in oed_saved.location.dataframe.columns
+            assert 'FlexiLocdefault_rename' in oed_saved.location.dataframe.columns
+
 
     def test_setting_schema_analysis__is_valid(self):
         file_name = 'analysis_settings.json'


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### add option to manage unknown column when saving files
When saving Exposure, add the option to manage unknown columns individually via a dict or generally via a single constant
option available are in UnknownColumnSaveOption
    IGNORE = 1
    RENAME = 2
    DELETE = 3
<!--end_release_notes-->
