### PR TITLE
Fix/improve check perils

### DIFF
--- a/ods_tools/oed/validator.py
+++ b/ods_tools/oed/validator.py
@@ -2,7 +2,6 @@ import functools
 import json
 import logging
 
-import pandas as pd
 from pathlib import Path
 from collections.abc import Iterable
 
@@ -65,7 +64,6 @@ class Validator:
             raise OdsException("Unsupported validation type")
 
         invalid_data_group = {}
-
         for check in validation:
             check_fct = getattr(self, 'check_' + str(check['name']), None)
             if check.get('on_error') not in VALIDATOR_ON_ERROR_ACTION:
@@ -106,6 +104,7 @@ class Validator:
                 invalid_data.append({'name': 'reinsurance', 'source': None,
                                      'msg': f"Exposure needs both ri_scope and ri_scope for reinsurance"
                                             f"ri_info={self.exposure.ri_info} ri_scope={self.exposure.ri_scope}"})
+
         return invalid_data
 
     def check_required_fields(self):
@@ -187,17 +186,24 @@ class Validator:
         Returns:
             list of invalid_data
         """
+        valid_perils = set(self.exposure.oed_schema.schema['perils']['info'])
+
+        def invalid_fct(perils):
+            invalid = []
+            for peril in perils.split(';'):
+                if peril not in valid_perils:
+                    invalid.append(peril)
+            return ';'.join(invalid)
+
         invalid_data = []
         for oed_source in self.exposure.get_oed_sources():
             identifier_field = self.identifier_field_maps[oed_source]
             if oed_source.dataframe.empty:
                 continue
             for column in oed_source.dataframe.columns.intersection(set(OED_PERIL_COLUMNS)):
-                peril_values = oed_source.dataframe[column].str.split(';').apply(pd.Series, 1).stack()
-                invalid_perils = oed_source.dataframe.iloc[
-                    peril_values[~peril_values.isin(
-                        set(self.exposure.oed_schema.schema['perils']['info']) | BLANK_VALUES
-                    )].index.droplevel(-1)]
+                invalid_perils_col = oed_source.dataframe[column].apply(invalid_fct)
+                invalid_perils = oed_source.dataframe[invalid_perils_col != '']
+                invalid_perils[column] = invalid_perils_col.loc[invalid_perils_col != '']
                 if not invalid_perils.empty:
                     invalid_data.append({'name': oed_source.oed_name, 'source': oed_source.current_source,
                                          'msg': f"{column} has invalid perils.\n"

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__file__)
 
 base_test_path = pathlib.Path(__file__).parent
 
-piwind_branch = 'develop'
+piwind_branch = 'main'
 base_url = f'https://raw.githubusercontent.com/OasisLMF/OasisPiWind/{piwind_branch}/tests/inputs'
 input_file_names = {
     "csv": {


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Improve performance of the peril check
On large file using the split stack method (.str.split(';').apply(pd.Series, 1).stack()) to get all the peril is costly.
Use a simple apply is actually much faster

<!--end_release_notes-->
