### PR TITLE
Add footprint file suffix options

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -353,18 +353,24 @@
                     "description": "Identifier for the event set file that is used for output calculations.",
                     "default": 1
                 },
-        "event_rates_set": {
-            "type": "string",
-            "title": "Event rates set file ID.",
-            "description": "Identifier for the event rates set file that is used for output calculations.",
-            "default": 1
-        },
+                "event_rates_set": {
+                    "type": "string",
+                    "title": "Event rates set file ID.",
+                    "description": "Identifier for the event rates set file that is used for output calculations.",
+                    "default": 1
+                },
                 "event_occurrence_id": {
                     "type": "string",
                     "title": "Event occurrence file ID.",
                     "description": "Identifier for the event occurrence file that is used for output calculations.",
                     "default": 1
-                }
+                },
+                "footprint_set": {
+                    "type": "string",
+		    "title": "Footprint set file ID.",
+		    "description": "Identifier for the footprint files that are used for output calculations.",
+		    "default": 1
+		}
             }
         },
         "gul_output": {

--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -297,6 +297,86 @@
                   "options"
                ]
             },
+            "footprint_set":{
+                "title":"Footprint set selector",
+		"description":"The 'id' field from options is used as a file suffix, e.g. footprint_<id>.bin, footprint_<id>.idx.z, footprint_<id>.parquet",
+		"type":"object",
+		"uniqueItems":false,
+		"additionalProperties": false,
+		"properties":{
+                    "name":{
+                        "type":"string",
+                        "title":"UI Option",
+                        "description":"UI name for selection",
+                        "minLength":1
+                    },
+                    "desc":{
+                        "type":"string",
+                        "title":"Short description",
+                        "description":"UI description for selection"
+                    },
+                    "used_for":{
+                       "type":"string",
+                       "title":"Where the setting is applied",
+                       "description":"Set if this parameter is ONLY used at input 'generation' or for output 'losses'",
+                       "enum":[
+                          "all",
+                          "generation",
+                          "losses"
+                       ]
+                    },
+                    "tooltip":{
+                       "type":"string",
+                       "title":"UI tooltip",
+                       "description":"Long description (optional)"
+                    },
+                    "default":{
+                       "type":"string",
+                       "title":"Default footprint set",
+                       "description":"Initial setting for footprint set"
+		    },
+                    "options":{
+                       "type":"array",
+                       "title":"Selection options for footprint",
+                       "description":"Array of possible footprint sets",
+                       "items":{
+                          "type":"object",
+                          "title":"Selection option element",
+                          "description":"Footprint set options",
+                          "additionalProperties":false,
+                          "properties":{
+                              "id":{
+                                  "type":"string",
+                                  "title":"footprint set suffix",
+                                  "description":"String value used to select a footprint set",
+                                  "minLength":1
+                              },
+                              "desc":{
+                                  "type":"string",
+                                  "title":"Footprint set description",
+                                  "description":"UI description for selection",
+                                  "minLength":1
+                              },
+                              "tooltip":{
+                                  "type":"string",
+                                  "title":"UI tooltip",
+                                  "description":"Long description (optional)"
+                              }
+                          },
+                          "required":[
+                              "id",
+                              "desc"
+                          ]
+                     }
+                  }
+               },
+               "required":[
+                  "name",
+                  "desc",
+                  "default",
+                  "options"
+               ]
+            },
             "valid_output_perspectives":{
                "type":"array",
                "title":"Globally supported loss perspectives",


### PR DESCRIPTION
<!--start_release_notes-->
### Add footprint file suffix options
An optional `footprint_set` model setting has been added to allow for the selection of footprint file according to the file suffix, which acts as the identifier. This allows footprints to be stored in multiple files rather than in a single master file. This is related to OasisLMF PR https://github.com/OasisLMF/OasisLMF/pull/1352.
<!--end_release_notes-->