### PR TITLE
make string column are writable when reading from parquet

### DIFF
--- a/ods_tools/oed/source.py
+++ b/ods_tools/oed/source.py
@@ -311,6 +311,7 @@ class OedSource:
                 to_tmp_dtype[column] = 'str'
                 if oed_df[column].dtype.name == 'category' and '' not in oed_df[column].dtype.categories:
                     oed_df[column] = oed_df[column].cat.add_categories('')
+                oed_df[column] = oed_df[column]  # make a copy f the col in case it is read_only
                 oed_df.loc[oed_df[column].isin(BLANK_VALUES), column] = ''
             elif pd_dtype[column].startswith('Int'):
                 to_tmp_dtype[column] = 'float'

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -404,10 +404,10 @@ class OdsPackageTests(TestCase):
             with tempfile.TemporaryDirectory() as tmp_dir:
                 abs_dir = pathlib.Path(tmp_dir, "abs")
                 abs_dir.mkdir()
-                with urllib.request.urlopen(base_url + '/SourceLocOEDPiWind10.csv') as response,\
+                with urllib.request.urlopen(base_url + '/SourceLocOEDPiWind10.csv') as response, \
                         open(pathlib.Path(tmp_dir, 'SourceLocOEDPiWind10.csv'), 'wb') as out_file:
                     shutil.copyfileobj(response, out_file)
-                with urllib.request.urlopen(base_url + '/SourceAccOEDPiWind.csv') as response,\
+                with urllib.request.urlopen(base_url + '/SourceAccOEDPiWind.csv') as response, \
                         open(pathlib.Path(abs_dir, 'SourceAccOEDPiWind.csv'), 'wb') as out_file:
                     shutil.copyfileobj(response, out_file)
 
@@ -477,7 +477,7 @@ class OdsPackageTests(TestCase):
             abs_dir = pathlib.Path(tmp_dir, "abs")
             abs_dir.mkdir()
 
-            with urllib.request.urlopen(file_url) as response,\
+            with urllib.request.urlopen(file_url) as response, \
                     open(pathlib.Path(tmp_dir, 'analysis_settings.json'), 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
 
@@ -499,7 +499,7 @@ class OdsPackageTests(TestCase):
             abs_dir = pathlib.Path(tmp_dir, "abs")
             abs_dir.mkdir()
 
-            with urllib.request.urlopen(file_url) as response,\
+            with urllib.request.urlopen(file_url) as response, \
                     open(pathlib.Path(tmp_dir, 'analysis_settings.json'), 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
 
@@ -529,7 +529,7 @@ class OdsPackageTests(TestCase):
             abs_dir = pathlib.Path(tmp_dir, "abs")
             abs_dir.mkdir()
 
-            with urllib.request.urlopen(file_url) as response,\
+            with urllib.request.urlopen(file_url) as response, \
                     open(pathlib.Path(tmp_dir, 'model_settings.json'), 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
 
@@ -551,7 +551,7 @@ class OdsPackageTests(TestCase):
             abs_dir = pathlib.Path(tmp_dir, "abs")
             abs_dir.mkdir()
 
-            with urllib.request.urlopen(file_url) as response,\
+            with urllib.request.urlopen(file_url) as response, \
                     open(pathlib.Path(tmp_dir, 'model_settings.json'), 'wb') as out_file:
                 shutil.copyfileobj(response, out_file)
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### make sure column are writable before modifying them when reading from parquet
<!--end_release_notes-->
