### PR TITLE
Add options to enable/disable post loss amplification, and set secondary and uniform post loss amplification factors

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -412,7 +412,21 @@
             "title": "Produce fully correlated output",
             "description": "If true generate losses for fully correlated output, i.e. no independence between groups, in addition to losses for default output.",
             "default": false
-        }
+        },
+	"pla": {
+	    "type": "boolean",
+	    "title": "Apply Post Loss Amplification",
+	    "description": "If true apply post loss amplification to losses",
+	    "default": false
+	},
+	"pla_secondary_factor": {
+	    "type": "number",
+	    "title": "Optional secondary factor for Post Loss Amplification",
+	    "description": "Secondary factor to be applied to post loss amplificaion",
+	    "default": 1,
+	    "minimum": 0,
+	    "maximum": 1
+	}
     },
     "required": [
         "model_supplier_id",

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -416,16 +416,23 @@
 	"pla": {
 	    "type": "boolean",
 	    "title": "Apply Post Loss Amplification",
-	    "description": "If true apply post loss amplification to losses",
+	    "description": "If true apply post loss amplification/reduction to losses.",
 	    "default": false
 	},
 	"pla_secondary_factor": {
 	    "type": "number",
 	    "title": "Optional secondary factor for Post Loss Amplification",
-	    "description": "Secondary factor to be applied to post loss amplificaion",
+	    "description": "Secondary factor to apply to post loss amplification/reduction factors.",
 	    "default": 1,
 	    "minimum": 0,
 	    "maximum": 1
+	},
+	"pla_uniform_factor": {
+	    "type": "number",
+	    "title": "Optional uniform factor for Post Loss Amplification",
+	    "description": "Uniform factor to apply across all losses.",
+	    "default": 0,
+	    "minimum": 0
 	}
     },
     "required": [


### PR DESCRIPTION
<!--start_release_notes-->
### Add options for post loss amplification/reduction.
The following options have been added:

- `pla` (bool): enable/disable post loss amplification.
- `pla_secondary_factor` (float): set the secondary loss factor to apply to post loss amplification/reduction factors.
- `pla_uniform_factor` (float): set the uniform loss factor to apply across all losses.

<!--end_release_notes-->
