### PR TITLE
Model_settings, allow additional properties under 'data_settings'

### DIFF
--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -299,11 +299,11 @@
             },
             "footprint_set":{
                 "title":"Footprint set selector",
-		"description":"The 'id' field from options is used as a file suffix, e.g. footprint_<id>.bin, footprint_<id>.idx.z, footprint_<id>.parquet",
-		"type":"object",
-		"uniqueItems":false,
-		"additionalProperties": false,
-		"properties":{
+                "description":"The 'id' field from options is used as a file suffix, e.g. footprint_<id>.bin, footprint_<id>.idx.z, footprint_<id>.parquet",
+                "type":"object",
+                "uniqueItems":false,
+                "additionalProperties": false,
+                "properties":{
                     "name":{
                         "type":"string",
                         "title":"UI Option",
@@ -334,7 +334,7 @@
                        "type":"string",
                        "title":"Default footprint set",
                        "description":"Initial setting for footprint set"
-		    },
+                    },
                     "options":{
                        "type":"array",
                        "title":"Selection options for footprint",
@@ -1092,7 +1092,7 @@
          "type":"object",
          "title":"Model data settings",
          "description":"Additional data options for a model",
-         "additionalProperties":false,
+         "additionalProperties":true,
          "properties":{
             "supported_oed_versions": {
                "title":"Supported OED Versions",

--- a/ods_tools/oed/setting_schema.py
+++ b/ods_tools/oed/setting_schema.py
@@ -239,6 +239,9 @@ class ModelSettingSchema(SettingSchema):
 
     def __init__(self, schema=None, json_path=None):
         self.SCHEMA_FILE = 'model_settings_schema.json'
+        self.compatibility_profile = [
+            CompatibilityMap(keys='group_fields', updated='damage_group_fields', ver='1.27.0'),
+        ]
         super(ModelSettingSchema, self).__init__(schema, json_path, 'model_settings')
 
 

--- a/ods_tools/oed/setting_schema.py
+++ b/ods_tools/oed/setting_schema.py
@@ -239,9 +239,6 @@ class ModelSettingSchema(SettingSchema):
 
     def __init__(self, schema=None, json_path=None):
         self.SCHEMA_FILE = 'model_settings_schema.json'
-        self.compatibility_profile = [
-            CompatibilityMap(keys='group_fields', updated='damage_group_fields', ver='1.27.0'),
-        ]
         super(ModelSettingSchema, self).__init__(schema, json_path, 'model_settings')
 
 


### PR DESCRIPTION
<!--start_release_notes-->
### Model_settings - allow additional properties under 'data_settings'
The rename of `group_fields` -> `damage_group_fields` can cause problems for OasisPlatform Servers where multiple model versions are running together.  

workers build from `1.15.x` and `1.23.x` required the older **group_fields** key, which fails validation without this PR. 
<!--end_release_notes-->
