### PR TITLE
Add fields for running aalcalcmeanonly ktools component

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -46,6 +46,12 @@
                         "description": "If true, output the average annual loss by level for the summary set.",
                         "default": false
                     },
+		    "aalcalcmeanonly": {
+			"type": "boolean",
+			"title": "AAL Mean Only calculaton flag",
+			"description": "If true, output the average annual loss by level for the summary set without calculating the standard deviation.",
+			"default": false
+		    },
                     "pltcalc": {
                         "type": "boolean",
                         "title": "PLT calculation flag",
@@ -166,6 +172,12 @@
                                 "description": "Period Average Loss Table (ORD Output flag)",
                                 "default": false
                             },
+			    "alt_meanonly": {
+				"type": "boolean",
+				"title": "ALT Mean Only",
+				"description": "Average Loss Table with no standard deviation calculation (ORD Output flag)",
+				"default": false
+			    },
                             "alct_convergence": {
                                 "type": "boolean",
                                 "title": "ALCT",


### PR DESCRIPTION
<!--start_release_notes-->
### Add fields for running aalcalcmeanonly ktools component
The `aalcalcmeanonly` ktools component calculates the overall average period loss, skipping the calculation of the standard deviation from this value. The following boolean fields have been introduced to the analysis settings file:

- `aalcalc_meanonly`: if true, output table in legacy format.
- `alt_meanonly`: if true, output table in ORD format.
<!--end_release_notes-->