### PR TITLE
Allow dependency between event set and footprint files

### DIFF
--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -133,6 +133,15 @@
                                  "minLength":1
                               }
                            },
+                           "valid_footprint_ids":{
+                              "type":"array",
+                              "title":"Supported footprint files",
+                              "description":"An optional list of viable footprint file ids to use with this event set",
+                              "items":{
+                                 "type":"string",
+                                 "minLength":1
+                              }
+                           },
                            "valid_perspectives":{
                               "type":"array",
                               "title":"Supported loss perspectives ",


### PR DESCRIPTION
Allow dependency between event set and footprint files #68 

<!--start_release_notes-->
### Model setting option to set dependency between event set and footprint files
* Added `valid_footprint_ids` per event set section 
<!--end_release_notes-->
