### PR TITLE
Fix missing model settings valid metrics

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -46,12 +46,12 @@
                         "description": "If true, output the average annual loss by level for the summary set.",
                         "default": false
                     },
-		    "aalcalcmeanonly": {
-			"type": "boolean",
-			"title": "AAL Mean Only calculaton flag",
-			"description": "If true, output the average annual loss by level for the summary set without calculating the standard deviation.",
-			"default": false
-		    },
+                    "aalcalcmeanonly": {
+                        "type": "boolean",
+                        "title": "AAL Mean Only calculaton flag",
+                        "description": "If true, output the average annual loss by level for the summary set without calculating the standard deviation.",
+                        "default": false
+                    },
                     "pltcalc": {
                         "type": "boolean",
                         "title": "PLT calculation flag",
@@ -172,12 +172,12 @@
                                 "description": "Period Average Loss Table (ORD Output flag)",
                                 "default": false
                             },
-			    "alt_meanonly": {
-				"type": "boolean",
-				"title": "ALT Mean Only",
-				"description": "Average Loss Table with no standard deviation calculation (ORD Output flag)",
-				"default": false
-			    },
+                            "alt_meanonly": {
+                                "type": "boolean",
+                                "title": "ALT Mean Only",
+                                "description": "Average Loss Table with no standard deviation calculation (ORD Output flag)",
+                                "default": false
+                            },
                             "alct_convergence": {
                                 "type": "boolean",
                                 "title": "ALCT",
@@ -379,10 +379,10 @@
                 },
                 "footprint_set": {
                     "type": "string",
-		    "title": "Footprint set file ID.",
-		    "description": "Identifier for the footprint files that are used for output calculations.",
-		    "default": 1
-		}
+            "title": "Footprint set file ID.",
+            "description": "Identifier for the footprint files that are used for output calculations.",
+            "default": 1
+        }
             }
         },
         "gul_output": {
@@ -425,27 +425,27 @@
             "description": "If true generate losses for fully correlated output, i.e. no independence between groups, in addition to losses for default output.",
             "default": false
         },
-	"pla": {
-	    "type": "boolean",
-	    "title": "Apply Post Loss Amplification",
-	    "description": "If true apply post loss amplification/reduction to losses.",
-	    "default": false
-	},
-	"pla_secondary_factor": {
-	    "type": "number",
-	    "title": "Optional secondary factor for Post Loss Amplification",
-	    "description": "Secondary factor to apply to post loss amplification/reduction factors.",
-	    "default": 1,
-	    "minimum": 0,
-	    "maximum": 1
-	},
-	"pla_uniform_factor": {
-	    "type": "number",
-	    "title": "Optional uniform factor for Post Loss Amplification",
-	    "description": "Uniform factor to apply across all losses.",
-	    "default": 0,
-	    "minimum": 0
-	}
+        "pla": {
+            "type": "boolean",
+            "title": "Apply Post Loss Amplification",
+            "description": "If true apply post loss amplification/reduction to losses.",
+            "default": false
+        },
+        "pla_secondary_factor": {
+            "type": "number",
+            "title": "Optional secondary factor for Post Loss Amplification",
+            "description": "Secondary factor to apply to post loss amplification/reduction factors.",
+            "default": 1,
+            "minimum": 0,
+            "maximum": 1
+        },
+        "pla_uniform_factor": {
+            "type": "number",
+            "title": "Optional uniform factor for Post Loss Amplification",
+            "description": "Uniform factor to apply across all losses.",
+            "default": 0,
+            "minimum": 0
+        }
     },
     "required": [
         "model_supplier_id",

--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -163,6 +163,7 @@
                                  "type":"string",
                                  "enum":[
                                     "aal",
+                                    "aalcalcmeanonly",
                                     "elt",
                                     "plt",
                                     "lec",
@@ -186,6 +187,8 @@
                                     "plt_quantile",
                                     "plt_moment",
                                     "alt_period",
+                                    "alt_meanonly",
+                                    "alct_confidence",
                                     "alct_convergence",
                                     "ept",
                                     "ept_full_uncertainty_aep",
@@ -407,6 +410,7 @@
                   "type":"string",
                   "enum":[
                      "aal",
+                     "aalcalcmeanonly",
                      "elt",
                      "plt",
                      "lec",
@@ -429,6 +433,8 @@
                      "plt_quantile",
                      "plt_moment",
                      "alt_period",
+                     "alt_meanonly",
+                     "alct_confidence",
                      "alct_convergence",
                      "ept",
                      "ept_full_uncertainty_aep",

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -827,16 +827,17 @@ class OdsPackageTests(TestCase):
         # # Assert the OccupancyCode is as expected
         assert oed_exposure.location.dataframe.loc[0, "OccupancyCode"] == 9995
 
-    def test_all_analysis_options__in_valid_metrics(self): 
+    def test_all_analysis_options__in_valid_metrics(self):
         model_schema = ModelSettingSchema().schema
-        analysis_schema = AnalysisSettingSchema().schema 
- 
-        # extract model settings 'valid_metrics' options, and check both match 
+        analysis_schema = AnalysisSettingSchema().schema
+
+        # extract model settings 'valid_metrics' options, and check both match
         global__valid_output_metrics = set(model_schema['properties']['model_settings']['properties']['valid_output_metrics']['items']['enum'])
-        event_set__valid_metrics = set(model_schema['properties']['model_settings']['properties']['event_set']['properties']['options']['items']['properties']['valid_metrics']['items']['enum'])
+        event_set__valid_metrics = set(model_schema['properties']['model_settings']['properties']['event_set']
+                                       ['properties']['options']['items']['properties']['valid_metrics']['items']['enum'])
         self.assertEqual(global__valid_output_metrics, event_set__valid_metrics)
 
-        # Build expected list from analysis settings schema. 
+        # Build expected list from analysis settings schema.
         excluded_keys_list = ['id', 'oed_fields', 'lec_output', 'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
         extra_keys_list = ['aal', 'elt', 'plt', 'lec', 'aep', 'oep', 'ept', 'psept']
 
@@ -844,7 +845,7 @@ class OdsPackageTests(TestCase):
             **analysis_schema['definitions']['output_summaries']['items']['properties'],
             **analysis_schema['definitions']['output_summaries']['items']['properties']['leccalc']['properties'],
             **analysis_schema['definitions']['output_summaries']['items']['properties']['ord_output']['properties']
-        }    
+        }
         expected_list = set(extra_keys_list + [k for k in settings_output_options if k not in excluded_keys_list])
 
         self.assertEqual(expected_list, global__valid_output_metrics)

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -826,3 +826,26 @@ class OdsPackageTests(TestCase):
 
         # # Assert the OccupancyCode is as expected
         assert oed_exposure.location.dataframe.loc[0, "OccupancyCode"] == 9995
+
+    def test_all_analysis_options__in_valid_metrics(self): 
+        model_schema = ModelSettingSchema().schema
+        analysis_schema = AnalysisSettingSchema().schema 
+ 
+        # extract model settings 'valid_metrics' options, and check both match 
+        global__valid_output_metrics = set(model_schema['properties']['model_settings']['properties']['valid_output_metrics']['items']['enum'])
+        event_set__valid_metrics = set(model_schema['properties']['model_settings']['properties']['event_set']['properties']['options']['items']['properties']['valid_metrics']['items']['enum'])
+        self.assertEqual(global__valid_output_metrics, event_set__valid_metrics)
+
+        # Build expected list from analysis settings schema. 
+        excluded_keys_list = ['id', 'oed_fields', 'lec_output', 'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
+        extra_keys_list = ['aal', 'elt', 'plt', 'lec', 'aep', 'oep', 'ept', 'psept']
+
+        settings_output_options = {
+            **analysis_schema['definitions']['output_summaries']['items']['properties'],
+            **analysis_schema['definitions']['output_summaries']['items']['properties']['leccalc']['properties'],
+            **analysis_schema['definitions']['output_summaries']['items']['properties']['ord_output']['properties']
+        }    
+        expected_list = set(extra_keys_list + [k for k in settings_output_options if k not in excluded_keys_list])
+
+        self.assertEqual(expected_list, global__valid_output_metrics)
+        self.assertEqual(expected_list, event_set__valid_metrics)


### PR DESCRIPTION
<!--start_release_notes-->
### Fix missing model settings valid metrics
* Added missing values `aalcalcmeanonly`, `alt_meanonly`, `alct_confidence` to **valid_metrics** sections in model_settings. 
* Added testing so missing values are caught next time. 
<!--end_release_notes-->
