### PR TITLE
Update CI triggers

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -5,7 +5,12 @@
 
 name: Code Quality
 
-on: [push]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - stable**
 
 env:
   max_line_length: 150

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 name: ODS-tools Testing
 
 on:
+  pull_request:
   push:
+    branches:
+      - main
+      - stable**
+
   workflow_dispatch:
     inputs:
       oed_spec_branch:


### PR DESCRIPTION
### Reduce Github actions load
Only run the full set of testing jobs when:
* A Pull Request is active 
* If a commit is pushed the to `main` or `stable/**` branches 
<!--end_release_notes-->
