### PR TITLE
Added fields to analysis settings schema

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -472,13 +472,7 @@
 	    "description": "Uniform factor to apply across all losses.",
 	    "default": 0,
 	    "minimum": 0
-	},
-    "vulnerability_adjustments": {
-        "type": ["string", "object"],
-        "title": "Optional adjustments to specific vulnerability IDs",
-        "description": "Either a dictionary of changes or the path of a file containing the data of specific vulnerability IDs",
-        "default": "1"
-    }
+	}
     },
     "required": [
         "model_supplier_id",

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -46,12 +46,12 @@
                         "description": "If true, output the average annual loss by level for the summary set.",
                         "default": false
                     },
-		    "aalcalcmeanonly": {
-			"type": "boolean",
-			"title": "AAL Mean Only calculaton flag",
-			"description": "If true, output the average annual loss by level for the summary set without calculating the standard deviation.",
-			"default": false
-		    },
+                    "aalcalcmeanonly": {
+                        "type": "boolean",
+                        "title": "AAL Mean Only calculaton flag",
+                        "description": "If true, output the average annual loss by level for the summary set without calculating the standard deviation.",
+                        "default": false
+                    },
                     "pltcalc": {
                         "type": "boolean",
                         "title": "PLT calculation flag",
@@ -172,12 +172,12 @@
                                 "description": "Period Average Loss Table (ORD Output flag)",
                                 "default": false
                             },
-			    "alt_meanonly": {
-				"type": "boolean",
-				"title": "ALT Mean Only",
-				"description": "Average Loss Table with no standard deviation calculation (ORD Output flag)",
-				"default": false
-			    },
+                            "alt_meanonly": {
+                                "type": "boolean",
+                                "title": "ALT Mean Only",
+                                "description": "Average Loss Table with no standard deviation calculation (ORD Output flag)",
+                                "default": false
+                            },
                             "alct_convergence": {
                                 "type": "boolean",
                                 "title": "ALCT",
@@ -382,7 +382,7 @@
                     "title": "Footprint set file ID.",
                     "description": "Identifier for the footprint files that are used for output calculations.",
                     "default": 1
-		        },
+                },
                 "vulnerability_set": {
                     "type": "string",
                     "title": "Vulnerability set file ID.",
@@ -394,20 +394,20 @@
                     "title": "Correlation Settings",
                     "description": "The Correlation Settings",
                     "items": {
-                       "type": "object",
-                       "properties": {
-                          "peril_correlation_group": {
-                             "type": "integer",
-                             "title": "Peril Correlation Group",
-                             "description": "The Peril Correlation Group",
-                             "minLength": 1
-                          },
-                          "correlation_value": {
-                             "type": "string",
-                             "title": "Correlation Value",
-                             "description": "The Correlation Value"
-                          }
-                       }
+                        "type": "object",
+                        "properties": {
+                            "peril_correlation_group": {
+                               "type": "integer",
+                               "title": "Peril Correlation Group",
+                               "description": "The Peril Correlation Group",
+                               "minLength": 1
+                            },
+                            "correlation_value": {
+                               "type": "string",
+                               "title": "Correlation Value",
+                               "description": "The Correlation Value"
+                            }
+                         }
                     }
                 }
             }
@@ -452,27 +452,27 @@
             "description": "If true generate losses for fully correlated output, i.e. no independence between groups, in addition to losses for default output.",
             "default": false
         },
-	"pla": {
-	    "type": "boolean",
-	    "title": "Apply Post Loss Amplification",
-	    "description": "If true apply post loss amplification/reduction to losses.",
-	    "default": false
-	},
-	"pla_secondary_factor": {
-	    "type": "number",
-	    "title": "Optional secondary factor for Post Loss Amplification",
-	    "description": "Secondary factor to apply to post loss amplification/reduction factors.",
-	    "default": 1,
-	    "minimum": 0,
-	    "maximum": 1
-	},
-	"pla_uniform_factor": {
-	    "type": "number",
-	    "title": "Optional uniform factor for Post Loss Amplification",
-	    "description": "Uniform factor to apply across all losses.",
-	    "default": 0,
-	    "minimum": 0
-	}
+        "pla": {
+            "type": "boolean",
+            "title": "Apply Post Loss Amplification",
+            "description": "If true apply post loss amplification/reduction to losses.",
+            "default": false
+        },
+        "pla_secondary_factor": {
+            "type": "number",
+            "title": "Optional secondary factor for Post Loss Amplification",
+            "description": "Secondary factor to apply to post loss amplification/reduction factors.",
+            "default": 1,
+            "minimum": 0,
+            "maximum": 1
+        },
+        "pla_uniform_factor": {
+            "type": "number",
+            "title": "Optional uniform factor for Post Loss Amplification",
+            "description": "Uniform factor to apply across all losses.",
+            "default": 0,
+            "minimum": 0
+        }
     },
     "required": [
         "model_supplier_id",

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -379,10 +379,16 @@
                 },
                 "footprint_set": {
                     "type": "string",
-		    "title": "Footprint set file ID.",
-		    "description": "Identifier for the footprint files that are used for output calculations.",
-		    "default": 1
-		}
+                    "title": "Footprint set file ID.",
+                    "description": "Identifier for the footprint files that are used for output calculations.",
+                    "default": 1
+		        },
+                "vulnerability_set": {
+                    "type": "string",
+                    "title": "Vulnerability set file ID.",
+                    "description": "Identifier for the vulnerability files that are used for output calculations.",
+                    "default": 1
+                }
             }
         },
         "gul_output": {

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -388,6 +388,27 @@
                     "title": "Vulnerability set file ID.",
                     "description": "Identifier for the vulnerability files that are used for output calculations.",
                     "default": 1
+                },
+                "correlation_settings": {
+                    "type": "array",
+                    "title": "Correlation Settings",
+                    "description": "The Correlation Settings",
+                    "items": {
+                       "type": "object",
+                       "properties": {
+                          "peril_correlation_group": {
+                             "type": "integer",
+                             "title": "Peril Correlation Group",
+                             "description": "The Peril Correlation Group",
+                             "minLength": 1
+                          },
+                          "correlation_value": {
+                             "type": "string",
+                             "title": "Correlation Value",
+                             "description": "The Correlation Value"
+                          }
+                       }
+                    }
                 }
             }
         },

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -451,7 +451,13 @@
 	    "description": "Uniform factor to apply across all losses.",
 	    "default": 0,
 	    "minimum": 0
-	}
+	},
+    "vulnerability_adjustments": {
+        "type": ["string", "object"],
+        "title": "Optional adjustments to specific vulnerability IDs",
+        "description": "Either a dictionary of changes or the path of a file containing the data of specific vulnerability IDs",
+        "default": "1"
+    }
     },
     "required": [
         "model_supplier_id",


### PR DESCRIPTION
<!--start_release_notes-->
### Added fields correlation_settings, vulnerability_set, and vulnerability_adjustments to the schema
Added fields used in PRs https://github.com/OasisLMF/OasisLMF/pull/1401 and https://github.com/OasisLMF/OasisLMF/pull/1406.
<!--end_release_notes-->

The fields are:
- correlation_settings: mirrors the one in model_settings;
- vulnerability_set: similarly to footprint_set, chooses specific vulnerability file by its extension;