### PR TITLE
Add vulnerability adjustments field to schema

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -412,6 +412,37 @@
                 }
             }
         },
+        "vulnerability_adjustments": {
+            "type": ["object", "string"],
+            "title": "Vulnerability Adjustments",
+            "description": "This can either be a JSON object with detailed settings (vulnerability ID and associated adjustments) or a path to a csv file with that data.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "Path to a CSV file containing vulnerability adjustments."
+                },
+                {
+                    "type": "object",
+                    "description": "Detailed vulnerability adjustment settings.",
+                    "patternProperties": {
+                        "^[0-9]+$": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 3,
+                                "maxItems": 3,
+                                "items": [
+                                    { "type": "integer" },
+                                    { "type": "integer" },
+                                    { "type": "number", "minimum": 0, "maximum": 1 }
+                                ]
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },
         "gul_output": {
             "type": "boolean",
             "title": "Produce GUL output",

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -412,18 +412,18 @@
                 }
             }
         },
-        "vulnerability_adjustments": {
+        "vulnerability_replacements": {
             "type": ["object", "string"],
-            "title": "Vulnerability Adjustments",
-            "description": "This can either be a JSON object with detailed settings (vulnerability ID and associated adjustments) or a path to a csv file with that data.",
+            "title": "Vulnerability Replacements",
+            "description": "This can either be a JSON object with detailed settings (vulnerability ID and associated replacement data) or a path to a csv file with that data.",
             "oneOf": [
                 {
                     "type": "string",
-                    "description": "Path to a CSV file containing vulnerability adjustments."
+                    "description": "Path to a CSV file containing vulnerability data to be replaced."
                 },
                 {
                     "type": "object",
-                    "description": "Detailed vulnerability adjustment settings.",
+                    "description": "Detailed vulnerability replacements.",
                     "patternProperties": {
                         "^[0-9]+$": {
                             "type": "array",
@@ -442,6 +442,18 @@
                     "additionalProperties": false
                 }
             ]
+        },
+        "vulnerability_adjustments": {
+            "type": "object",
+            "title": "Vulnerability Factor Adjustments",
+            "description": "Dictionary containing vulnerability adjustments with vulnerability ID as integer keys and adjustment factors as float values.",
+            "patternProperties": {
+                "^[0-9]+$": {
+                    "type": "number",
+                    "minimum": 0
+                }
+            },
+            "additionalProperties": false
         },
         "gul_output": {
             "type": "boolean",

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -412,17 +412,26 @@
                 }
             }
         },
-        "vulnerability_replacements": {
-            "type": ["object", "string"],
-            "title": "Vulnerability Replacements",
-            "description": "This can either be a JSON object with detailed settings (vulnerability ID and associated replacement data) or a path to a csv file with that data.",
-            "oneOf": [
-                {
-                    "type": "string",
-                    "description": "Path to a CSV file containing vulnerability data to be replaced."
-                },
-                {
+        "vulnerability_adjustments": {
+            "type": "object",
+            "title": "Vulnerability Adjustments",
+            "description": "Object containing vulnerability adjustments and replacements.",
+            "properties": {
+                "adjustments": {
                     "type": "object",
+                    "title": "Vulnerability Factor Adjustments",
+                    "description": "Dictionary containing vulnerability adjustments with vulnerability ID as integer keys and adjustment factors as float values.",
+                    "patternProperties": {
+                        "^[0-9]+$": {
+                            "type": "number",
+                            "minimum": 0
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "replace_data": {
+                    "type": "object",
+                    "title": "Vulnerability Replacements",
                     "description": "Detailed vulnerability replacements.",
                     "patternProperties": {
                         "^[0-9]+$": {
@@ -440,21 +449,15 @@
                         }
                     },
                     "additionalProperties": false
-                }
-            ]
-        },
-        "vulnerability_adjustments": {
-            "type": "object",
-            "title": "Vulnerability Factor Adjustments",
-            "description": "Dictionary containing vulnerability adjustments with vulnerability ID as integer keys and adjustment factors as float values.",
-            "patternProperties": {
-                "^[0-9]+$": {
-                    "type": "number",
-                    "minimum": 0
+                },
+                "replace_file": {
+                    "type": "string",
+                    "title": "Vulnerability Replacement File",
+                    "description": "Path to a CSV file containing vulnerability data to be replaced."
                 }
             },
             "additionalProperties": false
-        },
+        },    
         "gul_output": {
             "type": "boolean",
             "title": "Produce GUL output",

--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -389,6 +389,86 @@
                   "options"
                ]
             },
+            "vulnerability_set":{
+               "title":"Vulnerability set selector",
+               "description":"The 'id' field from options is used as a file suffix, e.g. vulnerability_<id>.bin, vulnerability_<id>.csv, vulnerability_<id>.parquet",
+               "type":"object",
+               "uniqueItems":false,
+               "additionalProperties": false,
+               "properties":{
+                   "name":{
+                       "type":"string",
+                       "title":"UI Option",
+                       "description":"UI name for selection",
+                       "minLength":1
+                   },
+                   "desc":{
+                       "type":"string",
+                       "title":"Short description",
+                       "description":"UI description for selection"
+                   },
+                   "used_for":{
+                      "type":"string",
+                      "title":"Where the setting is applied",
+                      "description":"Set if this parameter is ONLY used at input 'generation' or for output 'losses'",
+                      "enum":[
+                         "all",
+                         "generation",
+                         "losses"
+                      ]
+                   },
+                   "tooltip":{
+                      "type":"string",
+                      "title":"UI tooltip",
+                      "description":"Long description (optional)"
+                   },
+                   "default":{
+                      "type":"string",
+                      "title":"Default footprint set",
+                      "description":"Initial setting for vulnerability set"
+                   },
+                   "options":{
+                      "type":"array",
+                      "title":"Selection options for footprint",
+                      "description":"Array of possible vulnerability sets",
+                      "items":{
+                         "type":"object",
+                         "title":"Selection option element",
+                         "description":"Vulnerability set options",
+                         "additionalProperties":false,
+                         "properties":{
+                             "id":{
+                                 "type":"string",
+                                 "title":"Vulnerability set suffix",
+                                 "description":"String value used to select a vulnerability set",
+                                 "minLength":1
+                             },
+                             "desc":{
+                                 "type":"string",
+                                 "title":"Vulnerability set description",
+                                 "description":"UI description for selection",
+                                 "minLength":1
+                             },
+                             "tooltip":{
+                                 "type":"string",
+                                 "title":"UI tooltip",
+                                 "description":"Long description (optional)"
+                             }
+                         },
+                         "required":[
+                             "id",
+                             "desc"
+                         ]
+                    }
+                 }
+              },
+              "required":[
+                 "name",
+                 "desc",
+                 "default",
+                 "options"
+              ]
+           },
             "valid_output_perspectives":{
                "type":"array",
                "title":"Globally supported loss perspectives",

--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -529,6 +529,49 @@
                   ]
                }
             },
+            "vulnerability_adjustments": {
+               "type": "object",
+               "title": "Vulnerability Factor Adjustments",
+               "description": "Dictionary containing vulnerability adjustments with vulnerability ID as integer keys and adjustment factors as float values.",
+               "patternProperties": {
+                   "^[0-9]+$": {
+                       "type": "number",
+                       "minimum": 0
+                   }
+               },
+               "additionalProperties": false
+           },
+           "vulnerability_replacements": {
+            "type": ["object", "string"],
+            "title": "Vulnerability Replacements",
+            "description": "This can either be a JSON object with detailed settings (vulnerability ID and associated replacement data) or a path to a csv file with that data.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "description": "Path to a CSV file containing vulnerability data to be replaced."
+                },
+                {
+                    "type": "object",
+                    "description": "Detailed vulnerability replacements.",
+                    "patternProperties": {
+                        "^[0-9]+$": {
+                            "type": "array",
+                            "items": {
+                                "type": "array",
+                                "minItems": 3,
+                                "maxItems": 3,
+                                "items": [
+                                    { "type": "integer" },
+                                    { "type": "integer" },
+                                    { "type": "number", "minimum": 0, "maximum": 1 }
+                                ]
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ]
+        },                   
             "string_parameters":{
                "title":"Single string paramters",
                "type":"array",

--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -531,47 +531,50 @@
             },
             "vulnerability_adjustments": {
                "type": "object",
-               "title": "Vulnerability Factor Adjustments",
-               "description": "Dictionary containing vulnerability adjustments with vulnerability ID as integer keys and adjustment factors as float values.",
-               "patternProperties": {
-                   "^[0-9]+$": {
-                       "type": "number",
-                       "minimum": 0
+               "title": "Vulnerability Adjustments",
+               "description": "Object containing vulnerability adjustments and replacements.",
+               "properties": {
+                   "adjustments": {
+                       "type": "object",
+                       "title": "Vulnerability Factor Adjustments",
+                       "description": "Dictionary containing vulnerability adjustments with vulnerability ID as integer keys and adjustment factors as float values.",
+                       "patternProperties": {
+                           "^[0-9]+$": {
+                               "type": "number",
+                               "minimum": 0
+                           }
+                       },
+                       "additionalProperties": false
+                   },
+                   "replace_data": {
+                       "type": "object",
+                       "title": "Vulnerability Replacements",
+                       "description": "Detailed vulnerability replacements.",
+                       "patternProperties": {
+                           "^[0-9]+$": {
+                               "type": "array",
+                               "items": {
+                                   "type": "array",
+                                   "minItems": 3,
+                                   "maxItems": 3,
+                                   "items": [
+                                       { "type": "integer" },
+                                       { "type": "integer" },
+                                       { "type": "number", "minimum": 0, "maximum": 1 }
+                                   ]
+                               }
+                           }
+                       },
+                       "additionalProperties": false
+                   },
+                   "replace_file": {
+                       "type": "string",
+                       "title": "Vulnerability Replacement File",
+                       "description": "Path to a CSV file containing vulnerability data to be replaced."
                    }
                },
                "additionalProperties": false
-           },
-           "vulnerability_replacements": {
-            "type": ["object", "string"],
-            "title": "Vulnerability Replacements",
-            "description": "This can either be a JSON object with detailed settings (vulnerability ID and associated replacement data) or a path to a csv file with that data.",
-            "oneOf": [
-                {
-                    "type": "string",
-                    "description": "Path to a CSV file containing vulnerability data to be replaced."
-                },
-                {
-                    "type": "object",
-                    "description": "Detailed vulnerability replacements.",
-                    "patternProperties": {
-                        "^[0-9]+$": {
-                            "type": "array",
-                            "items": {
-                                "type": "array",
-                                "minItems": 3,
-                                "maxItems": 3,
-                                "items": [
-                                    { "type": "integer" },
-                                    { "type": "integer" },
-                                    { "type": "number", "minimum": 0, "maximum": 1 }
-                                ]
-                            }
-                        }
-                    },
-                    "additionalProperties": false
-                }
-            ]
-        },                   
+           },                          
             "string_parameters":{
                "title":"Single string paramters",
                "type":"array",


### PR DESCRIPTION
<!--start_release_notes-->
### analysis_settings_schema.json can contain vulnerability adjustments to apply

Added "vulnerability_replacements" and "vulnerability_adjustments" to the analysis settings schema. Added vulnerability_set to model settings schema.

<!--end_release_notes-->

Used in PR [#1415](https://github.com/OasisLMF/OasisLMF/pull/1415) and PR [#1426](https://github.com/OasisLMF/OasisLMF/pull/1426).

"vulnerability_replacements" can be either the path to a .csv file, or a dictionary containing the vulnerability_ids to replace (e.g. {"1": [[1,1,0.01],[1,2,0.02],...], "2": [[1,1,0.4],...]}.
"vulnerability_adjustments" should be a dictionary with vulnerability_ids as keys and adjustment factors as values (e.g. {"4": 1.1, "12": 0.895}.