### PR TITLE
Remove warning message

### DIFF
--- a/ods_tools/oed/setting_schema.py
+++ b/ods_tools/oed/setting_schema.py
@@ -133,7 +133,6 @@ class SettingSchema:
                 old_key = compat_map.keys.split('.')[-1]
                 new_key = compat_map.updated.split('.')[-1]
                 self._remap_key(settings_data, new_key, old_key)
-                self.logger.warning(f'Deprecated key in {self.settings_type}.json, "{old_key}" updated to "{new_key}"')
 
         return settings_data
 


### PR DESCRIPTION
<!--start_release_notes-->
### Remove Deprecated Key warning, 
The only checking done adds older keys `module_supplier_id` and `model_version_id` into the settings file  (needed for older workers. Having a warning here only add confusion and isn't needed.  
<!--end_release_notes-->
