### PR TITLE
Add ri_inuring_priorities field to analysis settings schema for outputs at intermediate inuring priorities

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -492,6 +492,16 @@
             "description": "Specified which outputs should be generated for which summary sets, for reinsurance net losses.",
             "$ref": "#/definitions/output_summaries"
         },
+	"ri_inuring_priorities": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "type": "integer",
+                "minimum": 1
+            },
+            "title": "Outputs at intermediate inuring priorities",
+            "description": "Request output at intervening inuring priorities specified as list of integers '[1, 3, 4 .. etc]'"
+        },
         "full_correlation": {
             "type": "boolean",
             "title": "Produce fully correlated output",


### PR DESCRIPTION
<!--start_release_notes-->
### Add ri_inuring_priorities field to analysis settings schema for outputs at intermediate inuring priorities
As `fmpy` can support concurrent net and gross reinsurance output streams, it becomes possible for the user to request output at intermediate inuring priorities. The following field has been added to facilitate this:

- `ri_inuring_priorities` (array of integers): values correspond to inuring priorities for which output is desired, e.g. `[1]`, `[1, 3, 4]`, etc.

<!--end_release_notes-->
