### PR TITLE
include peril group as valid when doing peril filtering

### DIFF
--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -133,6 +133,7 @@ class OedSchema:
         Args:
             peril_ids (pd.Series): peril that are checked
             peril_filters (pd.Series): peril groups to check against
+            include_sub_group (bool): if True condiders peril group as valid (WW1 is valid for AA1)
         :return:
             np.array of True and False
         """

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -101,6 +101,7 @@ class OedSchema:
 
     @cached_property
     def nb_perils_dict(self):
+        """dict peril group to sub_peril"""
         nb_perils_dict = nb.typed.Dict.empty(
             key_type=nb.types.UnicodeCharSeq(3),
             value_type=nb.types.UnicodeCharSeq(3)[:],
@@ -110,7 +111,23 @@ class OedSchema:
 
         return nb_perils_dict
 
-    def peril_filtering(self, peril_ids, peril_filters):
+    @cached_property
+    def nb_peril_groups_dict(self):
+        """ dict peril group to all included peril group """
+        nb_peril_groups_dict = nb.typed.Dict.empty(
+            key_type=nb.types.UnicodeCharSeq(3),
+            value_type=nb.types.UnicodeCharSeq(3)[:],
+        )
+        for peril_group_key, perils in self.schema['perils']['covered'].items():
+            peril_groups = []
+            for peril_group_include, perils_include in self.schema['perils']['covered'].items():
+                if not set(perils_include).difference(set(perils)):
+                    peril_groups.append(peril_group_include)
+            nb_peril_groups_dict[peril_group_key] = np.array(peril_groups, dtype='U3')
+        return nb_peril_groups_dict
+
+
+    def peril_filtering(self, peril_ids, peril_filters, include_sub_group = True):
         """
         check if peril_ids are part of the peril groups in peril_filters, both array need to match size
         Args:
@@ -119,7 +136,8 @@ class OedSchema:
         :return:
             np.array of True and False
         """
-        return jit_peril_filtering(peril_ids.to_numpy().astype('str'), peril_filters.to_numpy().astype('str'), self.nb_perils_dict)
+        return jit_peril_filtering(peril_ids.to_numpy().astype('str'), peril_filters.to_numpy().astype('str'),
+                                   self.nb_peril_groups_dict if include_sub_group else self.nb_perils_dict)
 
     @staticmethod
     def to_universal_field_name(column: str):

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -126,8 +126,7 @@ class OedSchema:
             nb_peril_groups_dict[peril_group_key] = np.array(peril_groups, dtype='U3')
         return nb_peril_groups_dict
 
-
-    def peril_filtering(self, peril_ids, peril_filters, include_sub_group = True):
+    def peril_filtering(self, peril_ids, peril_filters, include_sub_group=True):
         """
         check if peril_ids are part of the peril groups in peril_filters, both array need to match size
         Args:


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### When filtering for perils, include peril group as valid
Allow the method of OedSchema peril_filtering to also check if a peril group (peril that represent multiple sub perils) is included in peril_filters.
Previously only sub_perils could be valid

this new behavior is piloted by include_sub_group:
if False: # historical behavior
    WTC is valid for WW1
    WW1 is not  valid for WW1
     WW1 is not  valid for AA1
    AA1 is not valid for WW1
if True: # new behavior
    WTC is valid for WW1
    WW1 is  valid for WW1
     WW1 is valid for AA1
    AA1 is not valid for WW1

note:
    In OasisLMF this allow models to return a peril group as a key instead of imposing them to only use sub perils

<!--end_release_notes-->
