### PR TITLE
CI update - replace py3.7 with py3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     needs: [build-ods, build-odm]
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
<!--start_release_notes-->
### CI update - replace py3.7 with py3.11
Resolve testing failure `ERROR: No matching distribution found for fsspec>=2023.12.2` by ditching p3.7 checks 
<!--end_release_notes-->
