### PR TITLE
Update cede mappings (cladding)

### DIFF
--- a/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
+++ b/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
@@ -960,8 +960,6 @@ forward:
       - transformation: UserGeocodeMatchLevel
     FlexiLocWallCode:
       - transformation: WallType
-    # FlexiLocWallSidingCode: No description of the cladding code
-    #   - transformation: WallSiding
     FlexiLocWaterHeaterCode:
       - transformation: WaterHeater
     FlexiLocWeldingCode:

--- a/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
+++ b/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
@@ -57,6 +57,8 @@ forward:
       type: int
     City:
       type: string
+    Cladding:
+      type: int
     ColdFormedTube:
       type: int
     ColumnBasement:
@@ -414,6 +416,8 @@ forward:
       - transformation: BuildingShape
     BuildingTIV:
       - transformation: BuildingValue
+    BuildingTIV:
+      - transformation: ReplacementValueA
     Packaging:
       - transformation: |
           replace(
@@ -436,6 +440,8 @@ forward:
       - transformation: Chimney
     City:
       - transformation: City
+    Cladding:
+      - transformation: WallSidingCode
     CondTag:
       - transformation: SublimitArea
     ConstructionQuality:
@@ -954,8 +960,8 @@ forward:
       - transformation: UserGeocodeMatchLevel
     FlexiLocWallCode:
       - transformation: WallType
-    FlexiLocWallSidingCode:
-      - transformation: WallSiding
+    # FlexiLocWallSidingCode: No description of the cladding code
+    #   - transformation: WallSiding
     FlexiLocWaterHeaterCode:
       - transformation: WaterHeater
     FlexiLocWeldingCode:
@@ -1644,8 +1650,6 @@ reverse:
     FlexiLocUserGeocodeMatchLevel:
       type: string
     FlexiLocWallCode:
-      type: string
-    FlexiLocWallSidingCode:
       type: string
     FlexiLocWaterHeaterCode:
       type: string
@@ -3588,7 +3592,28 @@ reverse:
     WallCode:
       - transformation: FlexiLocWallCode
     WallSidingCode:
-      - transformation: FlexiLocWallSidingCode
+      - transformation: |
+          replace(
+          Cladding,
+          '0','0',
+          '1','1',
+          '2','2',
+          '3','3',
+          '4','4',
+          '5','5',
+          '6','6',
+          '7','7',
+          '8','0',
+          '9','0'
+          '10','0',
+          '11','0',
+          '12','0',
+          '13','0',
+          '14','0',
+          '15','0',
+          '16','0',
+          '17','0'
+          )
     WaterHeaterCode:
       - transformation: FlexiLocWaterHeaterCode
     WeldingCode:

--- a/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
+++ b/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
@@ -329,6 +329,8 @@ forward:
       #type: string
     WallSiding:
       type: int
+    WallSidingCode:
+      type: int
     WallType:
       type: int
     WaterHeater:
@@ -416,8 +418,6 @@ forward:
       - transformation: BuildingShape
     BuildingTIV:
       - transformation: BuildingValue
-    BuildingTIV:
-      - transformation: ReplacementValueA
     Packaging:
       - transformation: |
           replace(
@@ -1561,6 +1561,8 @@ reverse:
       type: int
     City:
       type: string
+    Cladding:
+      type: int
     CondTag:
       type: string
     ConstructionQuality:
@@ -2613,6 +2615,29 @@ reverse:
       - transformation: Chimney
     City:
       - transformation: City
+    Cladding:
+      - transformation: |
+          replace(
+          WallSidingCode,
+          '0','0',
+          '1','1',
+          '2','2',
+          '3','3',
+          '4','4',
+          '5','5',
+          '6','6',
+          '7','7',
+          '8','0',
+          '9','0'
+          '10','0',
+          '11','0',
+          '12','0',
+          '13','0',
+          '14','0',
+          '15','0',
+          '16','0',
+          '17','0'
+          )
     ColdFormedTubeCode:
       - transformation: FlexiLocColdFormedTubeCode
     ColumnBasementCode:
@@ -3591,29 +3616,6 @@ reverse:
       - transformation: WindowProtection
     WallCode:
       - transformation: FlexiLocWallCode
-    WallSidingCode:
-      - transformation: |
-          replace(
-          Cladding,
-          '0','0',
-          '1','1',
-          '2','2',
-          '3','3',
-          '4','4',
-          '5','5',
-          '6','6',
-          '7','7',
-          '8','0',
-          '9','0'
-          '10','0',
-          '11','0',
-          '12','0',
-          '13','0',
-          '14','0',
-          '15','0',
-          '16','0',
-          '17','0'
-          )
     WaterHeaterCode:
       - transformation: FlexiLocWaterHeaterCode
     WeldingCode:


### PR DESCRIPTION
### Map Cladding (OED) to WallSidingCode (Cede)
`WallSidingCode` information is now correctly stored in the `Cladding` column when converting Cede to OED (and vice versa)
<!--end_release_notes-->

0 to 7 maps directly, whatever value above 7 in the conversion OED->Cede is assigned value 0 (unknown).