### PR TITLE
Removed 'ord_output' from valid_metrics in model-settings

### DIFF
--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -187,8 +187,6 @@
                                     "wheatsheaf_mean_aep",
                                     "wheatsheaf_mean_oep",
                                     "wheatsheaf_oep",
-
-                                    "ord_output",
                                     "elt_sample",
                                     "elt_quantile",
                                     "elt_moment",
@@ -514,7 +512,6 @@
                      "wheatsheaf_mean_aep",
                      "wheatsheaf_mean_oep",
                      "wheatsheaf_oep",
-                     "ord_output",
                      "elt_sample",
                      "elt_quantile",
                      "elt_moment",

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -842,7 +842,7 @@ class OdsPackageTests(TestCase):
         self.assertEqual(global__valid_output_metrics, event_set__valid_metrics)
 
         # Build expected list from analysis settings schema.
-        excluded_keys_list = ['id', 'oed_fields', 'lec_output', 'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
+        excluded_keys_list = ['id', 'ord_output', 'oed_fields', 'lec_output', 'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
         extra_keys_list = ['aal', 'elt', 'plt', 'lec', 'aep', 'oep', 'ept', 'psept']
 
         settings_output_options = {

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -842,7 +842,8 @@ class OdsPackageTests(TestCase):
         self.assertEqual(global__valid_output_metrics, event_set__valid_metrics)
 
         # Build expected list from analysis settings schema.
-        excluded_keys_list = ['id', 'ord_output', 'oed_fields', 'lec_output', 'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
+        excluded_keys_list = ['id', 'ord_output', 'oed_fields', 'lec_output',
+                              'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
         extra_keys_list = ['aal', 'elt', 'plt', 'lec', 'aep', 'oep', 'ept', 'psept']
 
         settings_output_options = {


### PR DESCRIPTION
<!--start_release_notes-->
### Removed 'ord_output' from valid_metrics in model-settings
Fixed https://github.com/OasisLMF/ODS_Tools/issues/3  the option `ord_output` is a grouping of output types and not itself a metric, removed from `valid_metrics` options to avoid confusion 
<!--end_release_notes-->
