### PR TITLE
Remove summary groups max value

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -17,8 +17,7 @@
                         "multipleOf": 1,
                         "title": "Summary ID",
                         "description": "Identifier for the summary set.",
-                        "minimum": 1,
-                        "maximum": 9
+                        "minimum": 1
                     },
                     "oed_fields": {
                         "type": "array",


### PR DESCRIPTION
<!--start_release_notes-->
### Remove summary groups max value
With the feature https://github.com/OasisLMF/OasisLMF/pull/1482 more than 9 summary groups are now supported. 
<!--end_release_notes-->
