### PR TITLE
event ranges

### DIFF
--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -324,6 +324,11 @@
             "title": "User set event ids",
             "description": "List of event ids as integers '[1, 5, 123 .. etc]'"
         },
+        "event_ranges": {
+            "type": "string",
+            "title": "User set event id ranges",
+            "description": "Comma separated ist of event id ranges using hyphens as string '1-4,8,89-94 .. etc'"
+        },
         "peril_filter": {
             "type": "array",
             "minItems": 1,


### PR DESCRIPTION
linked to https://github.com/OasisLMF/OasisLMF/pull/1517                                                                              

<!--start_release_notes-->
### event range options in analysis settings schema

additional support for ranges of event ids in analysis schema.

new field "event ranges" (string) with format "1-4,8,84-98"

can be used in combination with existing event id array

<!--end_release_notes-->
