### PR TITLE
Transform air-oed without config file

### DIFF
--- a/ods_tools/main.py
+++ b/ods_tools/main.py
@@ -174,10 +174,14 @@ Transform data format to/from OED.
 """
 transform_command = command_parser.add_parser('transform', description=transform_description,
                                               formatter_class=argparse.RawTextHelpFormatter)
-transform_command.add_argument('--config-file', help='Path to the config file', required=True)
+transform_command.add_argument('--config-file', help='Path to the config file')
+transform_command.add_argument('--oed-air', help='directly transforms OED to AIR format', action='store_true')
+transform_command.add_argument('--air-oed', help='directly transforms AIR to OED format', action='store_true')
+transform_command.add_argument('--input-file', help='Path to the input file', default=None)
+transform_command.add_argument('--output-file', help='Path to the output file', default=None)
 transform_command.add_argument('-v', '--logging-level', help='logging level (debug:10, info:20, warning:30, error:40, critical:50)',
                                default=30, type=int)
-transform_command.add_argument('--nocheck', help='if True, OED file will not be checked after transformation', default=False)
+transform_command.add_argument('--nocheck', help='if True, OED file will not be checked after transformation', default=False, action='store_true')
 
 
 def main():

--- a/ods_tools/main.py
+++ b/ods_tools/main.py
@@ -99,7 +99,7 @@ def transform(**kwargs):
     try:
         if kwargs.get('config_file') is None:
             if kwargs.get('format') is None or kwargs.get('input_file') is None or kwargs.get('output_file') is None:
-                raise ValueError("When --config-file is not provided, --format, --input-file, and --output-file are required.")
+                raise OdsException("When --config-file is not provided, --format, --input-file, and --output-file are required.")
 
         transform_result = transform_format(path_to_config_file=kwargs.get('config_file'), input_file=kwargs.get('input_file'),
                                             output_file=kwargs.get('output_file'), transformation=kwargs.get('format'))
@@ -110,7 +110,6 @@ def transform(**kwargs):
                 elif output_file[1] == 'account' and os.path.isfile(output_file[0]):
                     check(account=output_file[0])
     except OdsException as e:
-        logger.error("Transformation failed:")
         logger.error(e)
 
 

--- a/ods_tools/main.py
+++ b/ods_tools/main.py
@@ -96,9 +96,9 @@ def convert(**kwargs):
 def transform(**kwargs):
     """Wrapper function for transform command.
     Transform location and account data to a new format (ex: AIR to OED)"""
-    path_to_config_file = kwargs['config_file']
     try:
-        transform_result = transform_format(path_to_config_file)
+        transform_result = transform_format(path_to_config_file=kwargs.get('config_file'), input_file=kwargs.get('input_file'),
+                                           output_file=kwargs.get('output_file'), transformation_type='oed-air' if kwargs.get('oed_air') else 'air-oed')
         if not kwargs.get('nocheck'):
             for output_file in transform_result:
                 if output_file[1] == 'location' and os.path.isfile(output_file[0]):
@@ -171,6 +171,11 @@ check_command.add_argument('-v', '--logging-level', help='logging level (debug:1
 
 transform_description = """
 Transform data format to/from OED.
+This transformation can be done either by providing a config file or directly by specifying the input and output files.
+If input and output files are provided, either --oed-air or --air-oed must be specified to indicate the transformation direction.
+
+If a config file is provided, the transformation will be done according to the config file.
+Please note that the config file allows for more options (batch size, file format, database connection, etc.)
 """
 transform_command = command_parser.add_parser('transform', description=transform_description,
                                               formatter_class=argparse.RawTextHelpFormatter)

--- a/ods_tools/main.py
+++ b/ods_tools/main.py
@@ -183,7 +183,6 @@ Please note that the config file allows for more options (batch size, file forma
 transform_command = command_parser.add_parser('transform', description=transform_description,
                                               formatter_class=argparse.RawTextHelpFormatter)
 transform_command.add_argument('--config-file', help='Path to the config file')
-transform_command.add_argument('--oed-air', help='directly transforms OED to AIR format', action='store_true')
 transform_command.add_argument('-f', "--format", help='Specify which transformation to use (currently oed-air or air-oed)', default=None)
 transform_command.add_argument('--input-file', help='Path to the input file', default=None)
 transform_command.add_argument('--output-file', help='Path to the output file', default=None)

--- a/ods_tools/main.py
+++ b/ods_tools/main.py
@@ -97,8 +97,12 @@ def transform(**kwargs):
     """Wrapper function for transform command.
     Transform location and account data to a new format (ex: AIR to OED)"""
     try:
+        if kwargs.get('config_file') is None:
+            if kwargs.get('format') is None or kwargs.get('input_file') is None or kwargs.get('output_file') is None:
+                raise ValueError("When --config-file is not provided, --format, --input-file, and --output-file are required.")
+
         transform_result = transform_format(path_to_config_file=kwargs.get('config_file'), input_file=kwargs.get('input_file'),
-                                            output_file=kwargs.get('output_file'), transformation_type='oed-air' if kwargs.get('oed_air') else 'air-oed')
+                                            output_file=kwargs.get('output_file'), transformation=kwargs.get('format'))
         if not kwargs.get('nocheck'):
             for output_file in transform_result:
                 if output_file[1] == 'location' and os.path.isfile(output_file[0]):
@@ -181,7 +185,7 @@ transform_command = command_parser.add_parser('transform', description=transform
                                               formatter_class=argparse.RawTextHelpFormatter)
 transform_command.add_argument('--config-file', help='Path to the config file')
 transform_command.add_argument('--oed-air', help='directly transforms OED to AIR format', action='store_true')
-transform_command.add_argument('--air-oed', help='directly transforms AIR to OED format', action='store_true')
+transform_command.add_argument('-f', "--format", help='Specify which transformation to use (currently oed-air or air-oed)', default=None)
 transform_command.add_argument('--input-file', help='Path to the input file', default=None)
 transform_command.add_argument('--output-file', help='Path to the output file', default=None)
 transform_command.add_argument('-v', '--logging-level', help='logging level (debug:10, info:20, warning:30, error:40, critical:50)',

--- a/ods_tools/main.py
+++ b/ods_tools/main.py
@@ -98,7 +98,7 @@ def transform(**kwargs):
     Transform location and account data to a new format (ex: AIR to OED)"""
     try:
         transform_result = transform_format(path_to_config_file=kwargs.get('config_file'), input_file=kwargs.get('input_file'),
-                                           output_file=kwargs.get('output_file'), transformation_type='oed-air' if kwargs.get('oed_air') else 'air-oed')
+                                            output_file=kwargs.get('output_file'), transformation_type='oed-air' if kwargs.get('oed_air') else 'air-oed')
         if not kwargs.get('nocheck'):
             for output_file in transform_result:
                 if output_file[1] == 'location' and os.path.isfile(output_file[0]):

--- a/ods_tools/odtf/controller.py
+++ b/ods_tools/odtf/controller.py
@@ -11,8 +11,8 @@ from .connector import BaseConnector
 from .mapping import BaseMapping
 from .runner import BaseRunner
 
-OED_VERSION = "2.0"
-AIR_VERSION = "1.0"
+OED_VERSION = "3.0.2"
+AIR_VERSION = "10.0.0"
 
 BASE_CONFIG = {
     "transformations": {
@@ -152,12 +152,12 @@ def generate_config(input_file, output_file, transformation_type):
     if transformation_type == 'oed-air':
         config_dict['transformations']['loc']['input_format']['name'] = 'OED_Location'
         config_dict['transformations']['loc']['input_format']['version'] = OED_VERSION
-        config_dict['transformations']['loc']['output_format']['name'] = 'AIR_Location'
+        config_dict['transformations']['loc']['output_format']['name'] = 'Cede_Location'
         config_dict['transformations']['loc']['output_format']['version'] = AIR_VERSION
         config_dict['transformations']['loc']['extractor']['options']['path'] = input_file
         config_dict['transformations']['loc']['loader']['options']['path'] = output_file
     elif transformation_type == 'air-oed':
-        config_dict['transformations']['loc']['input_format']['name'] = 'AIR_Location'
+        config_dict['transformations']['loc']['input_format']['name'] = 'Cede_Location'
         config_dict['transformations']['loc']['input_format']['version'] = AIR_VERSION
         config_dict['transformations']['loc']['output_format']['name'] = 'OED_Location'
         config_dict['transformations']['loc']['output_format']['version'] = OED_VERSION

--- a/ods_tools/odtf/controller.py
+++ b/ods_tools/odtf/controller.py
@@ -11,9 +11,11 @@ from .connector import BaseConnector
 from .mapping import BaseMapping
 from .runner import BaseRunner
 
+# Default versions for OED and AIR when running without a config file
 OED_VERSION = "3.0.2"
 AIR_VERSION = "10.0.0"
 
+# Default config when running without a config file
 BASE_CONFIG = {
     "transformations": {
         "loc": {
@@ -148,6 +150,21 @@ class Controller:
 
 
 def generate_config(input_file, output_file, transformation_type):
+    """
+    This function generates a config dictionary based on the input parameters.
+    When running without a config file, this will generate the config dict.
+
+    Args:
+        input_file (str): path to the input file
+        output_file (str): path to the output file
+        transformation_type (str): either 'oed-air' or 'air-oed'
+
+    Raises:
+        ValueError: if transformation_type is not 'oed-air' or 'air-oed'
+
+    Returns:
+        dict: the generated config dictionary
+    """
     config_dict = BASE_CONFIG
     if transformation_type == 'oed-air':
         config_dict['transformations']['loc']['input_format']['name'] = 'OED_Location'
@@ -164,11 +181,25 @@ def generate_config(input_file, output_file, transformation_type):
         config_dict['transformations']['loc']['extractor']['options']['path'] = input_file
         config_dict['transformations']['loc']['loader']['options']['path'] = output_file
     else:
-        raise ValueError('Invalid transformation type')
+        raise ValueError('Invalid transformation type. Only "oed-air" and "air-oed" are supported.')
     return config_dict
 
 
 def transform_format(path_to_config_file=None, input_file=None, output_file=None, transformation_type=None):
+    """This function takes the input parameters when called from ods_tools
+    and starts the transformation process. Either path_to_config_file or
+    all three input_file, output_file, and transformation_type must be provided.
+
+    Args:
+        path_to_config_file (str): path to the config file. Defaults to None.
+        input_file (str: path to the input file. Defaults to None.
+        output_file (str): path to the output file. Defaults to None.
+        transformation_type (str): Either 'oed-air' or 'air-oed'. Defaults to None.
+
+    Returns:
+        list: a list of tuples containing the output file path and the file type.
+        Used for checking the output files.
+    """
     if path_to_config_file:
         with open(path_to_config_file, 'r') as file:
             config_dict = yaml.safe_load(file)

--- a/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
+++ b/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
@@ -2626,7 +2626,7 @@ reverse:
           '6','6',
           '7','7',
           '8','0',
-          '9','0'
+          '9','0',
           '10','0',
           '11','0',
           '12','0',
@@ -3280,8 +3280,8 @@ reverse:
       - transformation: |
           replace_multiple(
             LocPeril,
+            ';',',',
             'WSS','CF',
-            ';',','
             'XCH','CH',
             'QEQ','EQ',
             'QFF','FF',

--- a/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
+++ b/ods_tools/odtf/data/mappings/mapping_loc_Cede-OED.yaml
@@ -2613,10 +2613,10 @@ reverse:
       - transformation: Chimney
     City:
       - transformation: City
-    Cladding:
+    WallSidingCode:
       - transformation: |
           replace(
-          WallSidingCode,
+          Cladding,
           '0','0',
           '1','1',
           '2','2',


### PR DESCRIPTION
<!--start_release_notes-->
### Transform air to oed without config file
A simple transformation from air to oed and vice versa can be run without creating a config file, but simply by command line
<!--end_release_notes-->

It is now possible to run a transformation without using a configuration file. Solves #125.

For example, the command:

`ods_tools transform --format air-oed --input-file air_input.csv --output-file oed_output.csv`

will produce the oed file `output.csv` from the air file `input.csv`
We currently support `air-oed` and `oed-air`.