### PR TITLE
Fix issue with lark 1.1.9

### DIFF
--- a/requirements-extra.in
+++ b/requirements-extra.in
@@ -1,5 +1,5 @@
 PyYAML
-lark <=1.1.9
+lark
 networkx
 pyodbc
 sqlparams

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -6,7 +6,7 @@ pytest
 requests
 chardet
 PyYAML
-lark<=1.1.9
+lark
 networkx
 pyodbc
 sqlparams

--- a/tests/t_input.csv
+++ b/tests/t_input.csv
@@ -7,5 +7,5 @@ Line,Input_int_1,Input_int_2,Input_string_1,Input_string_2,Input_multistring_1,I
 6,55,55,letter_F,letter_F,"letter_C, letter_I, letter_A",ARG,5.2,5.2
 7,101,101,letter_G,letter_G,"letter_B, letter_E, letter_E",,7.9,7.9
 8,999,999,letter_H,letter_H,"letter_J, letter_I, letter_I","USA, UK",111.11,111.11
-9,777,777,letter_I,letter_I,"letter_G, letter_I, letter_G",Null,0.001,0.001
+9,777,777,letter_I,letter_I,"letter_G, letter_I, letter_G",,0.001,0.001
 10,1,1,,,"letter_B, letter_A, letter_G","ARG, BRA, USA",,

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -9,6 +9,7 @@ import urllib
 import sys
 import yaml
 
+import lark
 import pandas as pd
 import numpy as np
 from unittest import TestCase
@@ -948,9 +949,10 @@ class OdsPackageTests(TestCase):
                                    0.000318471337579618, np.nan],
                 'Output_multistring_1': ["A;B;C", "A;J", "E;C", 'H', '', "C;I;A", "B;E;E", "J;I;I", "G;I;G", "B;A;G"],
                 'Output_multistring_2': ["United Kingdom;Italy", "Germany;Brasil", "France;France", "Sweden",
-                                         "Spain;Sweden", "Argentina", '', "United States;United Kingdom", "Null",
+                                         "Spain;Sweden", "Argentina", '', "United States;United Kingdom", '',
                                          "Argentina;Brasil;United States"]
             }
+
         for column, values in expected_values.items():
             if 'float' in column.lower():
                 assert np.allclose(output_df[column].tolist(), values, equal_nan=True, rtol=1e-5, atol=1e-5)

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -9,7 +9,6 @@ import urllib
 import sys
 import yaml
 
-import lark
 import pandas as pd
 import numpy as np
 from unittest import TestCase


### PR DESCRIPTION
<!--start_release_notes-->
### Fix failed transformations with lark > 1.1.9
Compatibility with all lark versions
<!--end_release_notes-->

Solves #140.

Removes the need for pinning lark to <= 1.1.9 in ods-tools requirements and ods-tools test requirements.