### PR TITLE
pin lark version

### DIFF
--- a/requirements-extra.in
+++ b/requirements-extra.in
@@ -1,5 +1,5 @@
 PyYAML
-lark
+lark <=1.1.9
 networkx
 pyodbc
 sqlparams

--- a/tests/requirements.in
+++ b/tests/requirements.in
@@ -6,7 +6,7 @@ pytest
 requests
 chardet
 PyYAML
-lark
+lark<=1.1.9
 networkx
 pyodbc
 sqlparams


### PR DESCRIPTION
<!--start_release_notes-->
### Pin lark version to <=1.9
While testing the solution, lark is pinned to a working version to avoid failing tests.
<!--end_release_notes-->
