### PR TITLE
Both correlation_settings fields are marked as "Legacy" in desc

### DIFF
--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -538,7 +538,7 @@
             "correlation_settings": {
                "type": "array",
                "title": "Correlation Settings",
-               "description": "The Legacy Correlation Settings.",
+               "description": "The Correlation Settings.",
                "items": {
                   "type": "object",
                   "properties": {


### PR DESCRIPTION
<!--start_release_notes-->
### Fixed 'correlation_settings' description in model settings 
There are two locations of `correlation_settings` one is **Legacy** which at the root of the file. The new version is within the `model_settings` attribute (fixed the description field to avoid confusion  
<!--end_release_notes-->
