### PR TITLE
Project PR action -  incorrectly running on external PRs

### DIFF
--- a/.github/workflows/project-PR.yml
+++ b/.github/workflows/project-PR.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   track_pr:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'OasisLMF'
+    if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Get project data
         env:


### PR DESCRIPTION
<!--start_release_notes-->
### Project PR action -  incorrectly running on external PRs
External PR fail on the actions Job 'Project PR' - disable this action if the PR is from a Fork
<!--end_release_notes-->
