### PR TITLE
Update OED schema to release v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import json
 
 SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
 
-OED_VERSION = '3.4.1'
+OED_VERSION = '4.0.0'
 # ORD_VERSION =
 
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               
<!--start_release_notes-->
### Update OED schema to release v4
The validation now uses the v4.0.0 version of OED. 
For more details on OED v4 see the [release notes](https://github.com/OasisLMF/ODS_OpenExposureData/releases/tag/4.0.0) 
<!--end_release_notes-->
