### PR TITLE
drop py3.8 testing but don't force the version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ setuptools.setup(
     author_email="support@oasislmf.org",
     packages=setuptools.find_packages(exclude=('tests', 'tests.*', 'tests.*.*')),
     package_dir={'ods_tools': 'ods_tools'},
-    python_requires='>=3.9',
+    python_requires='>=3.8',
     install_requires=reqs,
     extras_require={
         'extra': extra_reqs,


### PR DESCRIPTION
<!--start_release_notes-->
### drop py3.8 testing but don't force the version
Fix for CI 
<!--end_release_notes-->
