### PR TITLE
add summary_report_fields to model settings

### DIFF
--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -1391,6 +1391,14 @@
                "default": true,
                "deprecated": true
            },
+           "summary_report_fields": {
+               "type":"array",
+               "title":"Additional summary report fields",
+               "description":"If set, the exposure summary report will include additional breakdowns from the listed fields. Note that the field must exists in the exposure file.",
+               "items":{
+                  "type":"string"
+               }
+           },
            "string_parameters":{
                "$ref": "#/definition/extensible_parameters/properties/string_parameters"
            },


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### add `summary_report_fields` to model settings
- parameter to control additional fields output when generating the exposure summary report
- required by `TODO`
<!--end_release_notes-->
