### PR TITLE
make nb_peril_groups_dict more friendly with numba caching function

### DIFF
--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -32,6 +32,22 @@ def jit_peril_filtering(peril_ids, peril_filters, perils_dict):
     return result
 
 
+peril_groups_dict_key_type = nb.types.UnicodeCharSeq(3)
+peril_groups_dict_value_type = nb.types.UnicodeCharSeq(3)[:]
+
+
+@nb.jit(cache=True, nopython=True)
+def make_peril_groups_dict(peril_group_keys, peril_group_index, peril_lists):
+    nb_peril_groups_dict = nb.typed.Dict.empty(
+        key_type=peril_groups_dict_key_type,
+        value_type=peril_groups_dict_value_type,
+    )
+    for i in range(peril_group_keys.shape[0]):
+        nb_peril_groups_dict[peril_group_keys[i]] = peril_lists[peril_group_index[i]: peril_group_index[i + 1]]
+
+    return nb_peril_groups_dict
+
+
 class OedSchema:
     """
     Object managing information about a certain OED schema
@@ -118,17 +134,21 @@ class OedSchema:
     @cached_property
     def nb_peril_groups_dict(self):
         """ dict peril group to all included peril group """
-        nb_peril_groups_dict = nb.typed.Dict.empty(
-            key_type=nb.types.UnicodeCharSeq(3),
-            value_type=nb.types.UnicodeCharSeq(3)[:],
-        )
+        peril_group_keys = []
+        peril_group_index = []
+        peril_lists = []
+        index = 0
         for peril_group_key, perils in self.schema['perils']['covered'].items():
+            peril_group_keys.append(peril_group_key)
+            peril_group_index.append(index)
             peril_groups = []
             for peril_group_include, perils_include in self.schema['perils']['covered'].items():
                 if not set(perils_include).difference(set(perils)):
                     peril_groups.append(peril_group_include)
-            nb_peril_groups_dict[peril_group_key] = np.array(peril_groups, dtype='U3')
-        return nb_peril_groups_dict
+            peril_lists.extend(peril_groups)
+            index += len(peril_groups)
+        peril_group_index.append(index)
+        return make_peril_groups_dict(np.array(peril_group_keys, dtype='U3'), np.array(peril_group_index), np.array(peril_lists, dtype='U3'))
 
     def peril_filtering(self, peril_ids, peril_filters, include_sub_group=True):
         """


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### speed up peril filtering by making nb_peril_groups_dict more friendly with numba caching function
peril filtering is used for example in fm file generation. By using this implementation, the jitted function is better cached and will be faster once it has been run one.
<!--end_release_notes-->
