### PR TITLE
Fix for failed test

### DIFF
--- a/ods_tools/oed/validator.py
+++ b/ods_tools/oed/validator.py
@@ -391,7 +391,7 @@ class Validator:
                                      f"{first_val} != {oedversion_rows[idx]} at row {idx}"})
             # Check regex for oedversion
             for idx, val in enumerate(oedversion_rows):
-                if val is not None and not re.fullmatch(oedversion_re, val):
+                if not pd.isna(val) and not re.fullmatch(oedversion_re, str(val)):
                     invalid_data.append({'name': oed_source.oed_name, 'source': oed_source.current_source,
                                          'msg': f"Mismatched regex for \"OEDVersion\" found in exposure file."
                                          " Ensure all \"OEDVersion\" values are of format \"^v?\\d+\\.\\d+\\.\\d+$\". (e.g. v4.0.0 or 4.0.0)\n"


### PR DESCRIPTION
```
tests/test_ods_package.py:1192: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/ods_tools/oed/exposure.py:531: in check
    return validator(validation_config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/ods_tools/oed/validator.py:78: in __call__
    invalid_data_group.setdefault(check['on_error'], []).extend(check_fct())
                                                                ^^^^^^^^^^^
/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/site-packages/ods_tools/oed/validator.py:394: in check_oedversion_consistency
    if val is not None and not re.fullmatch(oedversion_re, val):
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def fullmatch(pattern, string, flags=0):
        """Try to apply the pattern to all of the string, returning
        a Match object, or None if no match was found."""
>       return _compile(pattern, flags).fullmatch(string)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E       TypeError: expected string or bytes-like object, got 'float'

```