### PR TITLE
fix/schema-validation

### DIFF
--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -206,7 +206,7 @@ class OedSchema:
             else:
                 return ''
         else:
-            if field_info['Default'] != 'n/a':
+            if field_info['Default'] not in ('n/a', ''):
                 return dtype_to_python[field_info['pd_dtype']](field_info['Default'])
             else:
                 return np.nan

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -98,13 +98,12 @@ class OedSchema:
                 dev_schema_path = cls.DEFAULT_ODS_SCHEMA_PATH.format('DEV')
                 logger.debug(f"attempting to load DEV schema {dev_schema_path}")
                 return cls.from_json(dev_schema_path)
-            except (FileNotFoundError, Exception) as e:
+            except FileNotFoundError as e:
                 logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
                 return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))
         if isinstance(oed_schema_info, str):
             if oed_schema_info == "latest version":
-                ods_tools_root = Path(__file__).resolve().parent.parent
-                oed_spec_files = glob(str(Path(ods_tools_root, "data/OpenExposureData_*Spec.json")))
+                oed_spec_files = glob(cls.DEFAULT_ODS_SCHEMA_PATH.format('*'))
 
                 version_pattern = re.compile("OpenExposureData_(\\d+\\.\\d+\\.\\d+)Spec\.json")
                 versions = [version_pattern.search(path).group(1) for path in oed_spec_files if version_pattern.search(path)]

--- a/ods_tools/oed/validator.py
+++ b/ods_tools/oed/validator.py
@@ -194,7 +194,7 @@ class Validator:
                     is_valid_value = functools.partial(OedSchema.is_valid_value,
                                                        valid_ranges=valid_ranges,
                                                        allow_blanks=blanks_allowed)
-                    invalid_range_data = oed_source.dataframe[~oed_source.dataframe[column].apply(is_valid_value)]
+                    invalid_range_data = oed_source.dataframe[~oed_source.dataframe[column].apply(is_valid_value).astype(bool)]
                     if not invalid_range_data.empty:
                         invalid_data.append({'name': oed_source.oed_name, 'source': oed_source.current_source,
                                              'msg': f"column '{column}' has values outside range.\n"

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -242,8 +242,9 @@ class OdsPackageTests(TestCase):
                                   'additional_fields': additional_fields_config
                                   })
 
-        assert exposure.location.dataframe['BIPOIType'].dtype == 'Int64'
-        assert exposure.location.dataframe['loc_id'].dtype == 'Int64'
+        expected_dtype = additional_fields_config['Loc']['BIPOIType'][exposure.backend_dtype]
+        assert str(exposure.location.dataframe['BIPOIType'].dtype) == expected_dtype
+        assert str(exposure.location.dataframe['loc_id'].dtype) == additional_fields_config['Loc']['loc_id'][exposure.backend_dtype]
 
         # check reading from file
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -252,8 +253,9 @@ class OdsPackageTests(TestCase):
 
             exposure = OedExposure(**{'location': loc_path, 'use_field': True,
                                       'additional_fields': additional_fields_config})
-            assert exposure.location.dataframe['BIPOIType'].dtype == 'Int64'
-            assert exposure.location.dataframe['loc_id'].dtype == 'Int64'
+            expected_dtype = additional_fields_config['Loc']['BIPOIType'][exposure.backend_dtype]
+            assert str(exposure.location.dataframe['BIPOIType'].dtype) == expected_dtype
+            assert str(exposure.location.dataframe['loc_id'].dtype) == additional_fields_config['Loc']['loc_id'][exposure.backend_dtype]
 
     def test_load_oed_from_stream(self):
         with tempfile.TemporaryDirectory() as tmp_run_dir:

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -234,7 +234,7 @@ class OdsPackageTests(TestCase):
         additional_fields_config = {
             'Loc': {
                 'loc_id': {'pd_dtype': 'Int64', 'pa_dtype': 'int64[pyarrow]'},
-                'BIPOIType': {'pd_dtype': 'Int64', 'pa_dtype': 'int64[pyarrow'}
+                'BIPOIType': {'pd_dtype': 'Int64', 'pa_dtype': 'int64[pyarrow]'}
             }
         }
 


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### fix/schema-validation

Fixes three bugs in schema loading and validation that caused errors when loading OED specs with certain field configurations.

### Changes

**`ods_tools/oed/oed_schema.py`**
- `get_default_value`: treat empty string `Default` the same as `'n/a'` — an empty `Default` was passed to `dtype_to_python[pd_dtype]()` causing an `AttributeError` when resolving `cr_field` on OED 3.0.0–3.0.3 specs
- DEV schema fallback: catch only `FileNotFoundError` instead of all exceptions, so unexpected errors surface rather than silently falling back to the default schema
- `"latest version"` lookup: use `cls.DEFAULT_ODS_SCHEMA_PATH.format('*')` for the glob, fixing incorrect path resolution when `ODS_SCHEMA_PATH` env var is set

**`ods_tools/oed/validator.py`**
- `valid_values` check: add `.astype(bool)` after `.apply(is_valid_value)` — pandas 3.0 no longer implicitly coerces a Categorical boolean series, causing the `~` inversion to raise a `TypeError`

**`tests/test_ods_package.py`**
- Fix malformed `pa_dtype='int64[pyarrow'` (missing `]`) in `test_load_oed__additional_fields`
- Update dtype assertions to use `exposure.backend_dtype` so the test is correct under both `pd_dtype` and `pa_dtype` backends

### Related

Required for https://github.com/OasisLMF/ODS_OpenExposureData/pull/272
Closes https://github.com/OasisLMF/ODS_Tools/issues/236 — `AttributeError: 'float' object has no attribute 'split'` on OED 3.0.0–3.0.3 specs
Closes https://github.com/OasisLMF/ODS_Tools/issues/237 — missing JSON specs for versions < 3.0.0 (specs will be added to releases separately via ODS_OpenExposureData)

<!--end_release_notes-->
