### PR TITLE
Deprecation from logger.warn -> logger.warning

### DIFF
--- a/ods_tools/combine/sampling.py
+++ b/ods_tools/combine/sampling.py
@@ -366,7 +366,7 @@ def do_loss_sampling_secondary_uncertainty(gpqt, group,
             elt_df = elt_dfs.get(f'{p.lower()}elt', None)
 
             if elt_df is None:
-                logger.warn(f"{p.lower()}elt not found for outputset_id {outputset_id}.")
+                logger.warning(f"{p.lower()}elt not found for outputset_id {outputset_id}.")
                 continue
 
             if p not in loss_sampling_func_map:

--- a/ods_tools/oed/settings.py
+++ b/ods_tools/oed/settings.py
@@ -546,7 +546,7 @@ class AnalysisSettingHandler(SettingHandler):
                             )
                             warning_msgs.append(msg)
 
-                            settings_logger.warn(
+                            settings_logger.warning(
                                 f" Deprecated option set in {summary_type} (summary ID: {summary_id}) - "
                                 f"'{field}' has no effect in (oasis 2.5.x and newer)."
                             )


### PR DESCRIPTION
Removing `warn` in favour of `warning` due to deprecations