### PR TITLE
Add 'rl' perspective to model_settings_schema enums (#1495)

### DIFF
--- a/ods_tools/data/model_settings_schema.json
+++ b/ods_tools/data/model_settings_schema.json
@@ -847,13 +847,14 @@
                            "valid_perspectives":{
                               "type":"array",
                               "title":"Supported loss perspectives ",
-                              "description":"If set, this event set only supports the given output perspectives. 'gul': ground up losses, 'il': insured losses, 'ri': reinsurance losses.",
+                              "description":"If set, this event set only supports the given output perspectives. 'gul': ground up losses, 'il': insured losses, 'ri': reinsurance net losses, 'rl': reinsurance losses at all inuring priorities.",
                               "items":{
                                  "type":"string",
                                  "enum":[
                                     "gul",
                                     "il",
-                                    "ri"
+                                    "ri",
+                                    "rl"
                                  ]
                               }
                            },
@@ -1252,13 +1253,14 @@
             "valid_output_perspectives":{
                "type":"array",
                "title":"Globally supported loss perspectives",
-               "description":"If set, the model only supports the given output perspectives. This can be overridden per event set using the 'valid_perspectives' field. 'gul': ground up losses, 'il': insured losses, 'ri': reinsurance losses.",
+               "description":"If set, the model only supports the given output perspectives. This can be overridden per event set using the 'valid_perspectives' field. 'gul': ground up losses, 'il': insured losses, 'ri': reinsurance net losses, 'rl': reinsurance losses at all inuring priorities.",
                "items":{
                   "type":"string",
                   "enum":[
                      "gul",
                      "il",
-                     "ri"
+                     "ri",
+                     "rl"
                   ]
                }
             },

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,8 @@
+import copy
 import unittest
 from pathlib import Path
 from ods_tools.oed import Settings, ModelSettingHandler, AnalysisSettingHandler
+from ods_tools.oed.common import OdsException
 
 
 test_data_dir = Path(Path(__file__).parent, "data")
@@ -160,3 +162,89 @@ class OEDSettingsChecks(unittest.TestCase):
         self.assertTrue("'bad_float' was unexpected" in str(context.exception))
         self.assertTrue("'bad_param' was unexpected" in str(context.exception))
         self.assertTrue("id 1 is duplicated" in str(context.exception))
+
+
+class ReinsuranceLossPerspectiveSchemaChecks(unittest.TestCase):
+    """Schema regression tests for the ``rl`` (reinsurance loss) perspective.
+
+    ``analysis_settings_schema.json`` already exposes ``rl_output`` /
+    ``rl_summaries``; ``model_settings_schema.json`` advertises supported
+    perspectives via two enums (top-level ``valid_output_perspectives`` and
+    per event-set ``valid_perspectives``). Both must accept ``rl``. See
+    OasisLMF#1495.
+    """
+
+    def setUp(self):
+        # Tests deep-copy this fixture before mutation so an in-place change
+        # by ``validate`` cannot leak across assertions within a single test.
+        self.model_settings = {
+            "model_settings": {
+                "event_set": {
+                    "name": "Event Set",
+                    "desc": "Event set selector",
+                    "default": "p1",
+                    "options": [
+                        {
+                            "id": "p1",
+                            "desc": "Primary event set",
+                            "valid_perspectives": ["gul", "il", "ri", "rl"],
+                        }
+                    ],
+                },
+                "valid_output_perspectives": ["gul", "il", "ri", "rl"],
+            },
+            "lookup_settings": {},
+        }
+
+    def test_rl_accepted_in_valid_output_perspectives(self):
+        handler = ModelSettingHandler.make()
+        ok, errors = handler.validate(copy.deepcopy(self.model_settings), raise_error=False)
+        self.assertTrue(ok, f"expected valid model_settings, got errors: {errors}")
+        self.assertEqual(errors, {})
+
+    def test_rl_accepted_in_event_set_valid_perspectives(self):
+        # Drop the top-level enum so a pass here can only be explained by the
+        # nested ``valid_perspectives`` enum accepting ``rl``.
+        data = copy.deepcopy(self.model_settings)
+        del data["model_settings"]["valid_output_perspectives"]
+        handler = ModelSettingHandler.make()
+        ok, errors = handler.validate(data, raise_error=False)
+        self.assertTrue(ok, f"expected valid model_settings, got errors: {errors}")
+
+    def test_unknown_perspective_rejected_in_valid_output_perspectives(self):
+        data = copy.deepcopy(self.model_settings)
+        data["model_settings"]["valid_output_perspectives"] = ["gul", "xyz"]
+        handler = ModelSettingHandler.make()
+        with self.assertRaises(OdsException) as ctx:
+            handler.validate(data)
+        message = str(ctx.exception)
+        self.assertIn("'xyz' is not one of", message)
+        # Anchor to the failing field path so a future regression that removed
+        # the nested enum can't be masked by the top-level enum's identical
+        # error wording.
+        self.assertIn("valid_output_perspectives", message)
+
+    def test_unknown_perspective_rejected_in_event_set_valid_perspectives(self):
+        data = copy.deepcopy(self.model_settings)
+        data["model_settings"]["event_set"]["options"][0]["valid_perspectives"] = [
+            "gul",
+            "xyz",
+        ]
+        handler = ModelSettingHandler.make()
+        with self.assertRaises(OdsException) as ctx:
+            handler.validate(data)
+        message = str(ctx.exception)
+        self.assertIn("'xyz' is not one of", message)
+        self.assertIn("event_set-options", message)
+
+    def test_existing_perspectives_still_accepted(self):
+        data = copy.deepcopy(self.model_settings)
+        data["model_settings"]["valid_output_perspectives"] = ["gul", "il", "ri"]
+        data["model_settings"]["event_set"]["options"][0]["valid_perspectives"] = [
+            "gul",
+            "il",
+            "ri",
+        ]
+        handler = ModelSettingHandler.make()
+        ok, errors = handler.validate(data, raise_error=False)
+        self.assertTrue(ok, f"expected valid pre-#1495 doc, got errors: {errors}")


### PR DESCRIPTION
## Summary

`analysis_settings_schema.json` already exposes the `rl_output` / `rl_summaries` fields for the `rl` (reinsurance loss) perspective, but `model_settings_schema.json` did not yet allow model authors to declare `rl` support — both supported-perspectives enums were limited to `gul` / `il` / `ri`. As flagged in #1495 (and on the 2025-12-08 design comment), this meant a model author who wanted to advertise reinsurance-loss support would trip schema validation.

This PR completes the partial fix by extending both enums to accept `rl`:

- `model_settings.valid_output_perspectives` (top-level)
- `model_settings.event_set.options[].valid_perspectives` (per event-set)

It also tightens the accompanying `description` strings to disambiguate `ri` (reinsurance **net** losses) from `rl` (reinsurance losses at **all inuring priorities**), matching the language already used by the `rl_output` / `rl_summaries` fields in `analysis_settings_schema.json`.

The change is intentionally minimal — just enum extensions + description clarification. No schema-shape churn, fully backward-compatible (only widens the allowed set, never narrows it).

## Test plan

A new `ReinsuranceLossPerspectiveSchemaChecks` test class in `tests/test_settings.py` covers both enum locations:

- [x] `test_rl_accepted_in_valid_output_perspectives` — happy path with `rl` in both locations
- [x] `test_rl_accepted_in_event_set_valid_perspectives` — strips the top-level enum so a pass can only come from the nested enum accepting `rl`
- [x] `test_unknown_perspective_rejected_in_valid_output_perspectives` — regression guard, anchored to the `valid_output_perspectives` field path
- [x] `test_unknown_perspective_rejected_in_event_set_valid_perspectives` — regression guard, anchored to the `event_set-options` path so the two negative tests can't mask each other
- [x] `test_existing_perspectives_still_accepted` — pre-#1495 documents (gul/il/ri only) continue to validate

CI gates verified locally:
- `pytest tests/test_settings.py` — 10/10 pass (5 new, 5 existing)
- `autopep8 --diff --exit-code --recursive --max-line-length 150 --ignore E402 .` — clean
- `flake8 --select F401,F522,F524,F541` — clean

## Out of scope (follow-up)

While auditing the change, I noticed two callers in this repo that still hardcode the perspective list and would not pick up `rl` even after this PR. They are intentionally **not** addressed here to keep the diff focused on the schema fix, but flagging them so maintainers can decide if a follow-up issue is warranted:

- `ods_tools/combine/grouping.py:98` — `perspectives = ['gul', 'il', 'ri']`
- `ods_tools/oed/settings.py` — `AnalysisSettingHandler.check_deprecated_ktools_outputs` (~line 532) and `check_unique_summary_ids` (~line 575) iterate `['gul', 'il', 'ri']` only

Closes #1495.