### PR TITLE
Fix/analysis settings empty fields

### DIFF
--- a/ods_tools/combine/examples/inputs/1/output/analysis_settings.json
+++ b/ods_tools/combine/examples/inputs/1/output/analysis_settings.json
@@ -107,8 +107,6 @@
         ]
     },
     "model_default_samples": 10,
-    "ri_summaries": [],
     "rl_output": false,
-    "rl_summaries": [],
     "number_of_samples": 10
 }

--- a/ods_tools/combine/examples/inputs/2/output/analysis_settings.json
+++ b/ods_tools/combine/examples/inputs/2/output/analysis_settings.json
@@ -107,8 +107,6 @@
         ]
     },
     "model_default_samples": 10,
-    "ri_summaries": [],
     "rl_output": false,
-    "rl_summaries": [],
     "number_of_samples": 10
 }

--- a/ods_tools/combine/examples/inputs/3/analysis_settings.json
+++ b/ods_tools/combine/examples/inputs/3/analysis_settings.json
@@ -115,6 +115,5 @@
     },
     "model_default_samples": 10,
     "rl_output": false,
-    "rl_summaries": [],
     "number_of_samples": 10
 }

--- a/ods_tools/combine/examples/inputs/3/output/analysis_settings.json
+++ b/ods_tools/combine/examples/inputs/3/output/analysis_settings.json
@@ -66,7 +66,6 @@
         }
     ],
     "ri_output": false,
-    "ri_summaries": [],
     "lookup_settings": {
         "supported_perils": [
             {
@@ -115,6 +114,5 @@
     },
     "model_default_samples": 10,
     "rl_output": false,
-    "rl_summaries": [],
     "number_of_samples": 10
 }

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -623,8 +623,6 @@
     "required": [
         "model_supplier_id",
         "model_name_id",
-        "model_settings",
-        "gul_output",
-        "gul_summaries"
+        "model_settings"
     ]
 }

--- a/ods_tools/data/analysis_settings_schema.json
+++ b/ods_tools/data/analysis_settings_schema.json
@@ -7,6 +7,7 @@
         "output_summaries": {
             "type": "array",
             "uniqueItems": false,
+            "minItems": 1,
             "title": "Insured loss summary outputs",
             "description": "Specified which outputs should be generated for which summary sets, for insured losses.",
             "items": {

--- a/ods_tools/oed/settings.py
+++ b/ods_tools/oed/settings.py
@@ -597,7 +597,7 @@ class AnalysisSettingHandler(SettingHandler):
 
         output_present = [p for p in perspectives if setting_data.get(f'{p}_output', False)]
         if not output_present:
-            exception_msgs['no output'] = ['no output selected, please enable at least one {runtype}_output']
+            exception_msgs['no output'] = ['no output selected, please enable at least one output']
 
         for p in output_present:
             if setting_data.get(f'{p}_summaries', None) is None:

--- a/ods_tools/oed/settings.py
+++ b/ods_tools/oed/settings.py
@@ -597,11 +597,11 @@ class AnalysisSettingHandler(SettingHandler):
 
         output_present = [p for p in perspectives if setting_data.get(f'{p}_output', False)]
         if not output_present:
-            exception_msgs['output_error'] = ['no output selected, please enable at least one output']
+            exception_msgs['no output'] = ['no output selected, please enable at least one {runtype}_output']
 
         for p in output_present:
             if setting_data.get(f'{p}_summaries', None) is None:
-                exception_msgs[f'{p}_summaries_missing'] = [f'{p}_output requested but {p}_summaries missing']
+                exception_msgs[f'{p}_summaries missing'] = [f'{p}_output requested but {p}_summaries missing']
 
         return exception_msgs
 

--- a/ods_tools/oed/settings.py
+++ b/ods_tools/oed/settings.py
@@ -13,6 +13,8 @@ settings_logger = logging.getLogger(__name__)
 ROOT_USER_ROLE = {'admin'}
 DATA_PATH = Path(Path(__file__).parent.parent, 'data')
 
+PERSPECTIVES = ['gul', 'il', 'ri', 'rl']
+
 
 def json_dict_walk(json_dict, key_path):
     """
@@ -529,7 +531,7 @@ class AnalysisSettingHandler(SettingHandler):
             'lec_output'
         ]
 
-        for summary_type in ['gul_summaries', 'il_summaries', 'ri_summaries']:
+        for summary_type in [f'{p}_summaries' for p in PERSPECTIVES]:
             if summary_type in setting_data:
                 summaries = setting_data[summary_type]
                 if not isinstance(summaries, list):
@@ -572,7 +574,7 @@ class AnalysisSettingHandler(SettingHandler):
 
         """
         exception_msgs = {}
-        runtype_summaries = [f'{runtype}_summaries' for runtype in ['gul', 'il', 'ri']]
+        runtype_summaries = [f'{runtype}_summaries' for runtype in PERSPECTIVES]
         for runtype_summary in runtype_summaries:
             summary_ids = [summary.get('id', []) for summary in setting_data.get(runtype_summary, [])]
             duplicate_ids = set(summary_id for summary_id in summary_ids if summary_ids.count(summary_id) > 1)
@@ -593,14 +595,13 @@ class AnalysisSettingHandler(SettingHandler):
             dict: Exception messages.
         """
         exception_msgs = {}
-        perspectives = ['gul', 'il', 'ri']
 
-        output_present = [p for p in perspectives if setting_data.get(f'{p}_output', False)]
+        output_present = [p for p in PERSPECTIVES if setting_data.get(f'{p}_output', False)]
         if not output_present:
             exception_msgs['no output'] = ['no output selected, please enable at least one output']
 
         for p in output_present:
-            if setting_data.get(f'{p}_summaries', None) is None:
+            if not setting_data.get(f'{p}_summaries', None):
                 exception_msgs[f'{p}_summaries missing'] = [f'{p}_output requested but {p}_summaries missing']
 
         return exception_msgs

--- a/ods_tools/oed/settings.py
+++ b/ods_tools/oed/settings.py
@@ -443,7 +443,7 @@ class SettingHandler:
 
 class AnalysisSettingHandler(SettingHandler):
     default_analysis_setting_schema_json = 'analysis_settings_schema.json'
-    extra_checks = ['unique_summary_ids', 'deprecated_ktools_outputs']
+    extra_checks = ['unique_summary_ids', 'deprecated_ktools_outputs', 'output_summaries']
     default_analysis_compatibility_profile = {
         "module_supplier_id": {
             "from_ver": "1.23.0",
@@ -579,6 +579,29 @@ class AnalysisSettingHandler(SettingHandler):
             if duplicate_ids:
                 error_msgs = [f'id {summary_id} is duplicated' for summary_id in duplicate_ids]
                 exception_msgs[runtype_summary] = error_msgs
+
+        return exception_msgs
+
+    def check_output_summaries(self, setting_data):
+        """
+        Ensure that at least one output is enabled and that all selected outputs have a summary.
+
+        Args:
+            setting_data (dict): The loaded JSON data.
+
+        Returns:
+            dict: Exception messages.
+        """
+        exception_msgs = {}
+        perspectives = ['gul', 'il', 'ri']
+
+        output_present = [p for p in perspectives if setting_data.get(f'{p}_output', False)]
+        if not output_present:
+            exception_msgs['output_error'] = ['no output selected, please enable at least one output']
+
+        for p in output_present:
+            if setting_data.get(f'{p}_summaries', None) is None:
+                exception_msgs[f'{p}_summaries_missing'] = [f'{p}_output requested but {p}_summaries missing']
 
         return exception_msgs
 

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -1230,6 +1230,7 @@ class OdsSettingsTests(TestCase):
         settings_dict['gul_output'] = False
         settings_dict['il_output'] = False
         settings_dict['ri_output'] = False
+        settings_dict['rl_output'] = False
 
         valid, errors = ods_analysis_setting.validate(settings_dict, raise_error=False)
         self.assertFalse(valid)

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -1165,9 +1165,10 @@ class OdsSettingsTests(TestCase):
     def logging_fixtures(self, caplog):
         self._caplog = caplog
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         self.tmp_dir = tempfile.TemporaryDirectory()
-        self.addCleanup(self.tmp_dir.cleanup)
+        self.addClassCleanup(self.tmp_dir.cleanup)
 
         # setup settings files
         parent_dir = pathlib.Path(self.tmp_dir.name) / 'piwind'
@@ -1178,9 +1179,10 @@ class OdsSettingsTests(TestCase):
         self.analysis_settings_path = self.setup_settings_path(parent_dir, base_file_url, 'analysis_settings.json')
         self.model_settings_path = self.setup_settings_path(parent_dir, base_file_url, 'meta-data/model_settings.json')
 
-        super().setUp()
+        super().setUpClass()
 
-    def setup_settings_path(self, parent_dir, base_file_url, file_name):
+    @staticmethod
+    def setup_settings_path(parent_dir, base_file_url, file_name):
         fpath = parent_dir / pathlib.Path(file_name).name
         file_url = f'{base_file_url}/{file_name}'
 

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -708,115 +708,6 @@ class OdsPackageTests(TestCase):
             assert 'ToDelete' not in oed_saved.location.dataframe.columns
             assert 'FlexiLocdefault_rename' in oed_saved.location.dataframe.columns
 
-    def test_setting_schema_analysis__is_valid(self):
-        file_name = 'analysis_settings.json'
-        file_url = f'https://raw.githubusercontent.com/OasisLMF/OasisPiWind/{piwind_branch}/{file_name}'
-        ods_analysis_setting = AnalysisSettingHandler.make()
-        assert (ods_analysis_setting.get_schema('analysis_settings_schema') is not None)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            abs_dir = pathlib.Path(tmp_dir, "abs")
-            abs_dir.mkdir()
-
-            with urllib.request.urlopen(file_url) as response, \
-                    open(pathlib.Path(tmp_dir, 'analysis_settings.json'), 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
-            settings_fp = pathlib.Path(tmp_dir, 'analysis_settings.json')
-            settings_dict = ods_analysis_setting.load(settings_fp)
-            valid, errors = ods_analysis_setting.validate(settings_dict)
-
-            self.assertTrue(valid)
-            self.assertEqual({}, errors)
-
-    def test_setting_schema_analysis__is_invalid(self):
-        file_name = 'analysis_settings.json'
-        file_url = f'https://raw.githubusercontent.com/OasisLMF/OasisPiWind/{piwind_branch}/{file_name}'
-        ods_analysis_setting = AnalysisSettingHandler.make()
-        assert (ods_analysis_setting.get_schema('analysis_settings_schema') is not None)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            abs_dir = pathlib.Path(tmp_dir, "abs")
-            abs_dir.mkdir()
-
-            with urllib.request.urlopen(file_url) as response, \
-                    open(pathlib.Path(tmp_dir, 'analysis_settings.json'), 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
-            settings_fp = pathlib.Path(tmp_dir, 'analysis_settings.json')
-            settings_dict = ods_analysis_setting.load(settings_fp)
-
-            # Insert errors
-            settings_dict['gul_summarie'] = settings_dict['gul_summaries']
-            del settings_dict['gul_summaries']
-            settings_dict['gul_output'] = "True"  # should be a bool
-            settings_dict['ri_summaries'].append(settings_dict['ri_summaries'][0])   # Duplicate summary ID
-
-            valid, errors = ods_analysis_setting.validate(settings_dict, raise_error=False)
-            self.assertFalse(valid)
-            expected_err = {
-                'ri_summaries': ['id 1 is duplicated'],
-                'analysis_settings_schema gul_output': ["'True' is not of type 'boolean'"],
-                'analysis_settings_schema required': ["'gul_summaries' is a required property"]
-            }
-            self.assertEqual(expected_err, errors)
-            with self.assertRaises(OdsException):
-                ods_analysis_setting.validate(settings_dict)
-
-    def test_setting_schema_model__is_valid(self):
-        file_name = 'meta-data/model_settings.json'
-        file_url = f'https://raw.githubusercontent.com/OasisLMF/OasisPiWind/{piwind_branch}/{file_name}'
-        ods_model_setting = ModelSettingHandler.make()
-        assert (ods_model_setting.get_schema('model_settings_schema') is not None)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            abs_dir = pathlib.Path(tmp_dir, "abs")
-            abs_dir.mkdir()
-
-            with urllib.request.urlopen(file_url) as response, \
-                    open(pathlib.Path(tmp_dir, 'model_settings.json'), 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
-            settings_fp = pathlib.Path(tmp_dir, 'model_settings.json')
-            settings_dict = ods_model_setting.load(settings_fp)
-            valid, errors = ods_model_setting.validate(settings_dict)
-
-            self.assertTrue(valid)
-            self.assertEqual({}, errors)
-
-    def test_setting_schema_model__is_invalid(self):
-        file_name = 'meta-data/model_settings.json'
-        file_url = f'https://raw.githubusercontent.com/OasisLMF/OasisPiWind/{piwind_branch}/{file_name}'
-        ods_model_setting = ModelSettingHandler.make()
-        assert (ods_model_setting.get_schema('model_settings_schema') is not None)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            abs_dir = pathlib.Path(tmp_dir, "abs")
-            abs_dir.mkdir()
-
-            with urllib.request.urlopen(file_url) as response, \
-                    open(pathlib.Path(tmp_dir, 'model_settings.json'), 'wb') as out_file:
-                shutil.copyfileobj(response, out_file)
-
-            settings_fp = pathlib.Path(tmp_dir, 'model_settings.json')
-            settings_dict = ods_model_setting.load(settings_fp)
-
-            # Insert errors
-            settings_dict['unknown_key'] = 'foobar'
-            settings_dict['model_setting'] = settings_dict['model_settings']
-            del settings_dict['model_settings']
-
-            valid, errors = ods_model_setting.validate(settings_dict, raise_error=False)
-            self.assertFalse(valid)
-            expected_err = {
-                'model_settings_schema additionalProperties': ["Additional properties are not allowed ('model_setting', 'unknown_key' were unexpected)"],
-                'model_settings_schema required': ["'model_settings' is a required property"]
-            }
-            self.assertEqual(expected_err, errors)
-
-            with self.assertRaises(OdsException):
-                ods_model_setting.validate(settings_dict)
-
     def test_empty_dataframe_logged(self):
         loc_df = pd.DataFrame({
             'PortNumber': [],
@@ -1071,31 +962,6 @@ class OdsPackageTests(TestCase):
         # # Assert the OccupancyCode is as expected
         assert oed_exposure.location.dataframe.loc[0, "OccupancyCode"] == 9995
 
-    def test_all_analysis_options__in_valid_metrics(self):
-        model_schema = ModelSettingHandler.make().get_schema('model_settings_schema')
-        analysis_schema = AnalysisSettingHandler.make().get_schema('analysis_settings_schema')
-
-        # extract model settings 'valid_metrics' options, and check both match
-        global__valid_output_metrics = set(model_schema['properties']['model_settings']['properties']['valid_output_metrics']['items']['enum'])
-        event_set__valid_metrics = set(model_schema['properties']['model_settings']['properties']['event_set']
-                                       ['properties']['options']['items']['properties']['valid_metrics']['items']['enum'])
-        self.assertEqual(global__valid_output_metrics, event_set__valid_metrics)
-
-        # Build expected list from analysis settings schema.
-        excluded_keys_list = ['id', 'ord_output', 'oed_fields', 'lec_output',
-                              'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
-        extra_keys_list = ['aal', 'elt', 'plt', 'lec', 'aep', 'oep', 'ept', 'psept']
-
-        settings_output_options = {
-            **analysis_schema['definitions']['output_summaries']['items']['properties'],
-            **analysis_schema['definitions']['output_summaries']['items']['properties']['leccalc']['properties'],
-            **analysis_schema['definitions']['output_summaries']['items']['properties']['ord_output']['properties']
-        }
-        expected_list = set(extra_keys_list + [k for k in settings_output_options if k not in excluded_keys_list])
-
-        self.assertEqual(expected_list, global__valid_output_metrics)
-        self.assertEqual(expected_list, event_set__valid_metrics)
-
     def test_probe_oedversion_from_oedsource(self):
         exposure = OedExposure(
             location=base_url + "/SourceLocOEDPiWind.csv",
@@ -1292,3 +1158,175 @@ class OdsPackageTests(TestCase):
         msg = str(e.exception)
         self.assertTrue("Mismatched \"OEDVersion\" value found in exposure file" in msg)
         self.assertTrue("v4 at row 0" in msg)
+
+
+class OdsSettingsTests(TestCase):
+    @pytest.fixture(autouse=True)
+    def logging_fixtures(self, caplog):
+        self._caplog = caplog
+
+    def setUp(self):
+        super().setUp()
+        self.tmp_dir = self.enterContext(tempfile.TemporaryDirectory())
+
+        # setup settings files
+        parent_dir = pathlib.Path(self.tmp_dir) / 'piwind'
+        parent_dir.mkdir(exist_ok=True)
+
+        base_file_url = f'https://raw.githubusercontent.com/OasisLMF/OasisPiWind/{piwind_branch}'
+
+        self.analysis_settings_path = self.setup_settings_path(parent_dir, base_file_url, 'analysis_settings.json')
+        self.model_settings_path = self.setup_settings_path(parent_dir, base_file_url, 'meta-data/model_settings.json')
+
+    def setup_settings_path(self, parent_dir, base_file_url, file_name):
+        fpath = parent_dir / pathlib.Path(file_name).name
+        file_url = f'{base_file_url}/{file_name}'
+
+        with urllib.request.urlopen(file_url) as response, \
+                open(fpath, 'wb') as out_file:
+            shutil.copyfileobj(response, out_file)
+
+        return fpath
+
+    def test_make_analysis_settings(self):
+        ods_analysis_setting = AnalysisSettingHandler.make()
+        assert (ods_analysis_setting.get_schema('analysis_settings_schema') is not None)
+
+    def test_setting_schema_analysis__is_valid(self):
+        ods_analysis_setting = AnalysisSettingHandler.make()
+        settings_dict = ods_analysis_setting.load(self.analysis_settings_path)
+        valid, errors = ods_analysis_setting.validate(settings_dict)
+
+        self.assertTrue(valid)
+        self.assertEqual({}, errors)
+
+    def test_setting_schema_analysis__is_invalid(self):
+        ods_analysis_setting = AnalysisSettingHandler.make()
+        settings_dict = ods_analysis_setting.load(self.analysis_settings_path)
+
+        # Insert errors
+        settings_dict['gul_summarie'] = settings_dict['gul_summaries']
+        del settings_dict['gul_summaries']
+        settings_dict['gul_output'] = "True"  # should be a bool
+        settings_dict['ri_summaries'].append(settings_dict['ri_summaries'][0])   # Duplicate summary ID
+
+        valid, errors = ods_analysis_setting.validate(settings_dict, raise_error=False)
+        self.assertFalse(valid)
+        expected_err = {
+            'ri_summaries': ['id 1 is duplicated'],
+            'analysis_settings_schema gul_output': ["'True' is not of type 'boolean'"],
+            'gul_summaries missing': ['gul_output requested but gul_summaries missing']
+        }
+        self.assertEqual(expected_err, errors)
+        with self.assertRaises(OdsException):
+            ods_analysis_setting.validate(settings_dict)
+
+    def test_setting_schema_analysis__output_missing(self):
+        ods_analysis_setting = AnalysisSettingHandler.make()
+        settings_dict = ods_analysis_setting.load(self.analysis_settings_path)
+
+        settings_dict['gul_output'] = False
+        settings_dict['il_output'] = False
+        settings_dict['ri_output'] = False
+
+        valid, errors = ods_analysis_setting.validate(settings_dict, raise_error=False)
+        self.assertFalse(valid)
+
+        expected_err = {
+            'no output': ['no output selected, please enable at least one output']
+        }
+
+        self.assertEqual(expected_err, errors)
+        with self.assertRaises(OdsException):
+            ods_analysis_setting.validate(settings_dict)
+
+    def test_setting_schema_analysis__check_output_summaries(self):
+        ods_analysis_setting = AnalysisSettingHandler.make()
+        settings_dict = ods_analysis_setting.load(self.analysis_settings_path)
+
+        settings_dict['gul_output'] = False
+        settings_dict['il_output'] = True
+        settings_dict['ri_output'] = False
+
+        # check missing
+        if 'il_summaries' in settings_dict:
+            del settings_dict['il_summaries']
+
+        valid, errors = ods_analysis_setting.validate(settings_dict, raise_error=False)
+        self.assertFalse(valid)
+
+        expected_err = {
+            'il_summaries missing': ['il_output requested but il_summaries missing']
+        }
+
+        self.assertEqual(expected_err, errors)
+        with self.assertRaises(OdsException):
+            ods_analysis_setting.validate(settings_dict)
+
+        # check valid
+        settings_dict['il_summaries'] = [
+            {'id': 1}
+        ]
+        valid, errors = ods_analysis_setting.validate(settings_dict)
+
+        self.assertTrue(valid)
+        self.assertEqual({}, errors)
+
+    def test_make_model_settings(self):
+        ods_analysis_setting = ModelSettingHandler.make()
+        assert (ods_analysis_setting.get_schema('model_settings_schema') is not None)
+
+    def test_setting_schema_model__is_valid(self):
+        ods_model_setting = ModelSettingHandler.make()
+
+        settings_dict = ods_model_setting.load(self.model_settings_path)
+        valid, errors = ods_model_setting.validate(settings_dict)
+
+        self.assertTrue(valid)
+        self.assertEqual({}, errors)
+
+    def test_setting_schema_model__is_invalid(self):
+        ods_model_setting = ModelSettingHandler.make()
+
+        settings_dict = ods_model_setting.load(self.model_settings_path)
+
+        # Insert errors
+        settings_dict['unknown_key'] = 'foobar'
+        settings_dict['model_setting'] = settings_dict['model_settings']
+        del settings_dict['model_settings']
+
+        valid, errors = ods_model_setting.validate(settings_dict, raise_error=False)
+        self.assertFalse(valid)
+        expected_err = {
+            'model_settings_schema additionalProperties': ["Additional properties are not allowed ('model_setting', 'unknown_key' were unexpected)"],
+            'model_settings_schema required': ["'model_settings' is a required property"]
+        }
+        self.assertEqual(expected_err, errors)
+
+        with self.assertRaises(OdsException):
+            ods_model_setting.validate(settings_dict)
+
+    def test_all_analysis_options__in_valid_metrics(self):
+        model_schema = ModelSettingHandler.make().get_schema('model_settings_schema')
+        analysis_schema = AnalysisSettingHandler.make().get_schema('analysis_settings_schema')
+
+        # extract model settings 'valid_metrics' options, and check both match
+        global__valid_output_metrics = set(model_schema['properties']['model_settings']['properties']['valid_output_metrics']['items']['enum'])
+        event_set__valid_metrics = set(model_schema['properties']['model_settings']['properties']['event_set']
+                                       ['properties']['options']['items']['properties']['valid_metrics']['items']['enum'])
+        self.assertEqual(global__valid_output_metrics, event_set__valid_metrics)
+
+        # Build expected list from analysis settings schema.
+        excluded_keys_list = ['id', 'ord_output', 'oed_fields', 'lec_output',
+                              'return_period_file', 'parquet_format', 'eltcalc', 'pltcalc', 'leccalc', 'aalcalc']
+        extra_keys_list = ['aal', 'elt', 'plt', 'lec', 'aep', 'oep', 'ept', 'psept']
+
+        settings_output_options = {
+            **analysis_schema['definitions']['output_summaries']['items']['properties'],
+            **analysis_schema['definitions']['output_summaries']['items']['properties']['leccalc']['properties'],
+            **analysis_schema['definitions']['output_summaries']['items']['properties']['ord_output']['properties']
+        }
+        expected_list = set(extra_keys_list + [k for k in settings_output_options if k not in excluded_keys_list])
+
+        self.assertEqual(expected_list, global__valid_output_metrics)
+        self.assertEqual(expected_list, event_set__valid_metrics)

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -1166,17 +1166,19 @@ class OdsSettingsTests(TestCase):
         self._caplog = caplog
 
     def setUp(self):
-        super().setUp()
-        self.tmp_dir = self.enterContext(tempfile.TemporaryDirectory())
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
 
         # setup settings files
-        parent_dir = pathlib.Path(self.tmp_dir) / 'piwind'
+        parent_dir = pathlib.Path(self.tmp_dir.name) / 'piwind'
         parent_dir.mkdir(exist_ok=True)
 
         base_file_url = f'https://raw.githubusercontent.com/OasisLMF/OasisPiWind/{piwind_branch}'
 
         self.analysis_settings_path = self.setup_settings_path(parent_dir, base_file_url, 'analysis_settings.json')
         self.model_settings_path = self.setup_settings_path(parent_dir, base_file_url, 'meta-data/model_settings.json')
+
+        super().setUp()
 
     def setup_settings_path(self, parent_dir, base_file_url, file_name):
         fpath = parent_dir / pathlib.Path(file_name).name


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### Fix analysis settings validation for empty fields and required outputs

Closes #270 — addresses two inconsistencies in `analysis_settings.json` validation:

- **`gul_summaries` no longer unconditionally required**: removed `gul_output` and `gul_summaries` from the schema's `required` array. Instead, a new `check_output_summaries` method validates that at least one output perspective (`gul`, `il`, `ri`, `rl`) is enabled and that each enabled output has a corresponding non-empty `*_summaries` list.
- **`output_summaries` arrays enforce `minItems: 1`**: aligns with the existing behaviour on other array fields, ensuring empty lists are consistently rejected (applies to all perspective `*_summaries` files)

Additional: 
- Refactored setting schema testing to download schema once in the `setUpClass` method
<!--end_release_notes-->
