### PR TITLE
Fix MSSQL connector ignoring custom port

### DIFF
--- a/ods_tools/odtf/connector/db/mssql.py
+++ b/ods_tools/odtf/connector/db/mssql.py
@@ -24,11 +24,13 @@ class SQLServerConnector(BaseDBConnector):
         """
 
         try:
+            server = database["host"]
+            if database.get("port"):
+                server = f"{server},{database['port']}"
             conn = pyodbc.connect(
-                "DRIVER={};SERVER={};PORT={};DATABASE={};UID={};PWD={}".format(
+                "DRIVER={};SERVER={};DATABASE={};UID={};PWD={}".format(
                     self.driver,
-                    database["host"],
-                    database["port"],
+                    server,
                     database["database"],
                     database["user"],
                     database["password"],


### PR DESCRIPTION
## Summary

- Fixes #150
- `PORT=` is not a valid keyword for the Microsoft ODBC Driver for SQL Server — connections on a custom port were silently failing
- The correct format is `SERVER=hostname,port`; the port is now conditionally appended to the host string and omitted when not set

## Test plan

- [ ] Configure an MSSQL extractor with an explicit `port` value and confirm connection succeeds
- [ ] Confirm connection still works when `port` is omitted (defaults to empty string)
- [ ] Confirm existing behaviour for default port (1433) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)