### PR TITLE
Updated build and packaging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,10 +90,12 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.BUILD_GIT_TOKEN }}
 
     # Testing only - not for release
-    - name: Buildpackage (from OED schema file)
+    - name: Build package (from OED schema file)
       if: inputs.oed_spec_json != '' || inputs.oed_spec_branch != ''
       run: |
-        python setup.py bdist_wheel install "--local-oed-spec=${{ github.workspace }}/OpenExposureData_Spec.json"
+        cp ${{ github.workspace }}/OpenExposureData_Spec.json ods_tools/data/OpenExposureData_DEVSpec.json
+        python setup.py sdist
+        python setup.py bdist_wheel
       env:
         GITHUB_TOKEN: ${{ secrets.BUILD_GIT_TOKEN }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,13 +70,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: 3.9
-    - run: pip install pip-tools pandas pyarrow openpyxl==3.0.10 click tox wheel
+    - run: pip install build pip-tools pandas pyarrow openpyxl==3.0.10 click tox wheel
 
     - name: Build package (from OED release)
       if: inputs.oed_spec_json == '' && inputs.oed_spec_branch == ''
-      run: |
-        python setup.py sdist
-        python setup.py bdist_wheel
+      run: python -m build
       env:
         GITHUB_TOKEN: ${{ secrets.BUILD_GIT_TOKEN }}
 
@@ -94,8 +92,7 @@ jobs:
       if: inputs.oed_spec_json != '' || inputs.oed_spec_branch != ''
       run: |
         cp ${{ github.workspace }}/OpenExposureData_Spec.json ods_tools/data/OpenExposureData_DEVSpec.json
-        python setup.py sdist
-        python setup.py bdist_wheel
+        python -m build
       env:
         GITHUB_TOKEN: ${{ secrets.BUILD_GIT_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     needs: [build-ods, build-odm]
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       oed_spec_branch: ${{ inputs.oed_spec_branch }}
 
   build-odm:
-    uses: OasisLMF/OasisDataManager/.github/workflows/build.yml@main
+    uses: OasisLMF/OasisDataManager/.github/workflows/build.yml@develop
     secrets: inherit
     with:
       odm_branch: ${{ github.event_name != 'workflow_dispatch' && 'develop' ||  inputs.odm_branch }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     needs: [build-ods, build-odm]
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["setuptools>=67"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ods_tools"
+dynamic = ["version", "dependencies", "optional-dependencies"]
+description = "Tools to manage ODS files"
+readme = "README.md"
+requires-python = ">=3.8"
+authors = [{name = "Oasis LMF", email = "support@oasislmf.org"}]
+
+[project.urls]
+Homepage = "https://github.com/OasisLMF/OpenDataStandards"
+
+[project.scripts]
+ods_tools = "ods_tools.main:main"
+
+[tool.setuptools.dynamic]
+version = {attr = "ods_tools.__version__"}
+dependencies = {file = ["requirements.in"]}
+optional-dependencies.extra = {file = ["requirements-extra.in"]}
+
+[tool.setuptools.packages.find]
+exclude = ["tests", "tests.*", "tests.*.*"]
+
+[tool.setuptools.package-data]
+"*" = ["*.md"]
+"ods_tools" = ["data/*", "odtf/data/**/*"]

--- a/setup.py
+++ b/setup.py
@@ -1,47 +1,15 @@
-import io
 import os
-import re
-import setuptools
+import json
+import urllib.request
 from urllib.error import HTTPError
 
+from setuptools import setup
 from setuptools.command.build_py import build_py
 from setuptools.command.editable_wheel import editable_wheel
 
-import urllib.request
-import json
-
-
-SCRIPT_DIR = os.path.abspath(os.path.dirname(__file__))
-
-# ORD_VERSION =
-
-
-def get_readme():
-    with io.open(os.path.join(SCRIPT_DIR, 'README.md'), encoding='utf-8') as readme:
-        return readme.read()
-
-
-def get_version():
-    """
-    Return package version as listed in `__version__` in `init.py`.
-    """
-    with io.open(os.path.join(SCRIPT_DIR, 'ods_tools', '__init__.py'), encoding='utf-8') as init_py:
-        return re.search('__version__ = [\'"]([^\'"]+)[\'"]', init_py.read()).group(1)
-
-
-def get_install_requirements():
-    with io.open(os.path.join(SCRIPT_DIR, 'requirements.in'), encoding='utf-8') as reqs:
-        return reqs.readlines()
-
-
-def get_extra_requirements():
-    with io.open(os.path.join(SCRIPT_DIR, 'requirements-extra.in'), encoding='utf-8') as extrareqs:
-        return extrareqs.readlines()
-
 
 class DownloadSpecODSBase:
-    """Base class for supporting downloading OEDSpec
-    """
+    """Base class for supporting downloading OEDSpec"""
     description = 'Download a ODS JSON spec file from a release URL.'
 
     def __init__(self, *args, **kwargs):
@@ -53,10 +21,8 @@ class DownloadSpecODSBase:
         self.skip_if_present = False
 
     def run(self):
-        # Install all releases
         print(f'Install all versions from url: {self.url}')
         tags = self.get_all_tags()
-        data = {}
         for tag in tags:
             try:
                 download_path = os.path.join(getattr(self, self.src_path_attr), 'ods_tools', 'data', self.filename.format(tag))
@@ -126,39 +92,7 @@ class DownloadSpecODS(DownloadSpecODSBase, build_py):
         DownloadSpecODSBase.run(self)
 
 
-version = get_version()
-readme = get_readme()
-reqs = get_install_requirements()
-extra_reqs = get_extra_requirements()
-
-setuptools.setup(
-    name="ods_tools",
-    version=version,
-    include_package_data=True,
-    package_data={
-        "": ["*.md"],                # Copy in readme
-        "ods_tools": ["data/*", "odtf/data/**/*"]  # Copy spec JSON/CSV and YAML mappings
-    },
-    entry_points={
-        'console_scripts': [
-            'ods_tools=ods_tools.main:main',
-        ]
-    },
-    author='Oasis LMF',
-    author_email="support@oasislmf.org",
-    packages=setuptools.find_packages(exclude=('tests', 'tests.*', 'tests.*.*')),
-    package_dir={'ods_tools': 'ods_tools'},
-    python_requires='>=3.8',
-    install_requires=reqs,
-    extras_require={
-        'extra': extra_reqs,
-    },
-    description='Tools to manage ODS files',
-    long_description=readme,
-    long_description_content_type='text/markdown',
-    url='https://github.com/OasisLMF/OpenDataStandards',
-    cmdclass={
-        'build_py': DownloadSpecODS,
-        'editable_wheel': DownloadSpecODSEditable
-    },
-)
+setup(cmdclass={
+    'build_py': DownloadSpecODS,
+    'editable_wheel': DownloadSpecODSEditable,
+})

--- a/setup.py
+++ b/setup.py
@@ -100,12 +100,7 @@ class DownloadSpecODSBase:
 
 
 class DownloadSpecODSEditable(DownloadSpecODSBase, editable_wheel):
-    """A custom command to download a JSON ODS spec during installation.
-
-        Example Install:
-            pip install -v . --install-option="--local-oed-spec=<path>" .
-
-    """
+    """Custom editable_wheel command that downloads OED spec JSON files during build."""
 
     def __init__(self, *args, **kwargs):
         DownloadSpecODSBase.__init__(self, *args, **kwargs)
@@ -119,46 +114,16 @@ class DownloadSpecODSEditable(DownloadSpecODSBase, editable_wheel):
 
 
 class DownloadSpecODS(DownloadSpecODSBase, build_py):
-    """A custom command to download a JSON ODS spec during installation.
-
-        Example Install:
-            pip install -v . --install-option="--local-oed-spec=<path>" .
-
-    """
-    user_options = build_py.user_options + [
-        ('local-oed-spec=', None, 'Override to build package with extracted spec (filepath)'),
-    ]
+    """Custom build_py command that downloads OED spec JSON files during build."""
 
     def __init__(self, *args, **kwargs):
         DownloadSpecODSBase.__init__(self, *args, **kwargs)
         build_py.__init__(self, *args, **kwargs)
         self.src_path_attr = 'build_lib'
 
-    def initialize_options(self):
-        build_py.initialize_options(self)
-        self.local_oed_spec = None
-
-    def finalize_options(self):
-        print("Local OED Spec:", str(self.local_oed_spec))
-        if self.local_oed_spec is not None:
-            if not os.path.isfile(self.local_oed_spec):
-                raise ValueError(f"Local OED Spec '{self.local_oed_spec}' not found")
-        build_py.finalize_options(self)
-
     def run(self):
         build_py.run(self)
         DownloadSpecODSBase.run(self)
-
-        if self.local_oed_spec:
-            # Install with local json spec
-            print('OED Version: Local File')
-            print(f'Install from path: {self.local_oed_spec}')
-            with open(self.local_oed_spec, 'r') as f:
-                data = json.load(f)
-                download_path = os.path.join(self.build_lib, 'ods_tools', 'data', self.filename.format('DEV'))
-                with open(download_path, 'w+') as f:
-                    json.dump(data, f)
-                data['version'] = 'DEV'
 
 
 version = get_version()

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import setuptools
 from urllib.error import HTTPError
 
 from setuptools.command.install import install
+from setuptools.command.build_py import build_py
 from setuptools.command.editable_wheel import editable_wheel
 
 import urllib.request
@@ -118,24 +119,24 @@ class DownloadSpecODSEditable(DownloadSpecODSBase, editable_wheel):
         editable_wheel.run(self)
 
 
-class DownloadSpecODS(DownloadSpecODSBase, install):
+class DownloadSpecODS(DownloadSpecODSBase, build_py):
     """A custom command to download a JSON ODS spec during installation.
 
         Example Install:
             pip install -v . --install-option="--local-oed-spec=<path>" .
 
     """
-    user_options = install.user_options + [
+    user_options = build_py.user_options + [
         ('local-oed-spec=', None, 'Override to build package with extracted spec (filepath)'),
     ]
 
     def __init__(self, *args, **kwargs):
         DownloadSpecODSBase.__init__(self, *args, **kwargs)
-        install.__init__(self, *args, **kwargs)
+        build_py.__init__(self, *args, **kwargs)
         self.src_path_attr = 'build_lib'
 
     def initialize_options(self):
-        install.initialize_options(self)
+        build_py.initialize_options(self)
         self.local_oed_spec = None
 
     def finalize_options(self):
@@ -143,9 +144,10 @@ class DownloadSpecODS(DownloadSpecODSBase, install):
         if self.local_oed_spec is not None:
             if not os.path.isfile(self.local_oed_spec):
                 raise ValueError(f"Local OED Spec '{self.local_oed_spec}' not found")
-        install.finalize_options(self)
+        build_py.finalize_options(self)
 
     def run(self):
+        build_py.run(self)
         DownloadSpecODSBase.run(self)
 
         if self.local_oed_spec:
@@ -158,8 +160,6 @@ class DownloadSpecODS(DownloadSpecODSBase, install):
                 with open(download_path, 'w+') as f:
                     json.dump(data, f)
                 data['version'] = 'DEV'
-
-        install.run(self)
 
 
 version = get_version()
@@ -194,7 +194,7 @@ setuptools.setup(
     long_description_content_type='text/markdown',
     url='https://github.com/OasisLMF/OpenDataStandards',
     cmdclass={
-        'install': DownloadSpecODS,
+        'build_py': DownloadSpecODS,
         'editable_wheel': DownloadSpecODSEditable
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,6 @@ import re
 import setuptools
 from urllib.error import HTTPError
 
-from setuptools.command.install import install
 from setuptools.command.build_py import build_py
 from setuptools.command.editable_wheel import editable_wheel
 


### PR DESCRIPTION
<!--start_release_notes-->
###  Updated build and pacakging of ods-tools
* Fixed build issue in CI by switching from sub-classing `build_py` instead of `install`
* Removed the `--local-oed-spec` flag, logic for download custom spec is moved into build workflow
* Moving to using `pyproject.toml` over `setup.py`
<!--end_release_notes-->




## The issue it fixes (i hope) 
*  https://github.com/OasisLMF/OasisPlatform/actions/runs/28031232030/job/82972169246
* [ods-tools_build_err.txt](https://github.com/user-attachments/files/29284929/ods-tools_build_err.txt)
