### PR TITLE
enhance/remove_dev_schema

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ on:
       whl_filename:
         description: "Wheel Package filename"
         value: ${{ jobs.build.outputs.whl_filename }}
+      has_dev_spec:
+        description: "Whether a dev OED spec was baked into the wheel"
+        value: ${{ jobs.build.outputs.has_dev_spec }}
 
 jobs:
   oed_spec:
@@ -44,6 +47,7 @@ jobs:
     outputs:
       src_filename: ${{ steps.build_package.outputs.source }}
       whl_filename: ${{ steps.build_package.outputs.wheel }}
+      has_dev_spec: ${{ steps.build_package.outputs.has_dev_spec }}
 
     steps:
     - name: Github context
@@ -103,6 +107,7 @@ jobs:
         SRC=$(find ./dist/ -name "*.tar.gz"  -exec basename {} \;)
         echo "wheel=$WHL" >> $GITHUB_OUTPUT
         echo "source=$SRC" >> $GITHUB_OUTPUT
+        echo "has_dev_spec=${{ inputs.oed_spec_branch != '' || inputs.oed_spec_json != '' }}" >> $GITHUB_OUTPUT
 
     - name: Store source package
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,11 @@ jobs:
     - name: Activate dev OED spec
       if: needs.build-ods.outputs.has_dev_spec == 'true'
       run: |
-        DEV_SPEC=$(python -c "import ods_tools, os; print(os.path.join(os.path.dirname(ods_tools.__file__), 'data', 'OpenExposureData_DEVSpec.json'))")
+        DEV_SPEC=$(python -c "
+        import sys; sys.path = [p for p in sys.path if p]
+        import ods_tools, os
+        print(os.path.join(os.path.dirname(ods_tools.__file__), 'data', 'OpenExposureData_DEVSpec.json'))
+        ")
         echo "ODS_SCHEMA_OVERRIDE=$DEV_SPEC" >> $GITHUB_ENV
 
     - name: Install test deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
         pip install ${{ needs.build-odm.outputs.whl_filename }}
         pip install ${{ needs.build-ods.outputs.whl_filename }}
 
+    - name: Activate dev OED spec
+      if: needs.build-ods.outputs.has_dev_spec == 'true'
+      run: |
+        DEV_SPEC=$(python -c "import ods_tools, os; print(os.path.join(os.path.dirname(ods_tools.__file__), 'data', 'OpenExposureData_DEVSpec.json'))")
+        echo "ODS_SCHEMA_OVERRIDE=$DEV_SPEC" >> $GITHUB_ENV
+
     - name: Install test deps
       run: pip install -r tests/requirements.in
 

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -94,13 +94,8 @@ class OedSchema:
             OedSchema
         """
         if oed_schema_info is None or oed_schema_info == "":
-            try:
-                dev_schema_path = cls.DEFAULT_ODS_SCHEMA_PATH.format('DEV')
-                logger.debug(f"attempting to load DEV schema {dev_schema_path}")
-                return cls.from_json(dev_schema_path)
-            except FileNotFoundError as e:
-                logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
-                return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))
+            logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
+            return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))
         if isinstance(oed_schema_info, str):
             if oed_schema_info == "latest version":
                 oed_spec_files = glob(cls.DEFAULT_ODS_SCHEMA_PATH.format('*'))

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -15,6 +15,7 @@ OED_VERSION = '5.0.0'
 logger = logging.getLogger(__name__)
 
 ENV_ODS_SCHEMA_PATH = os.getenv('ODS_SCHEMA_PATH')
+ENV_ODS_SCHEMA_OVERRIDE = os.getenv('ODS_SCHEMA_OVERRIDE')
 
 
 # function to check if a subperil is part of a peril
@@ -93,6 +94,9 @@ class OedSchema:
         Returns:
             OedSchema
         """
+        if ENV_ODS_SCHEMA_OVERRIDE:
+            logger.debug(f"loading schema override: {ENV_ODS_SCHEMA_OVERRIDE}")
+            return cls.from_json(ENV_ODS_SCHEMA_OVERRIDE)
         if oed_schema_info is None or oed_schema_info == "":
             logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
             return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### enhance/remove_dev_schema

Removes the implicit `DEVSpec.json` auto-load from `from_oed_schema_info(None)` (issue #231) and replaces it with an explicit `ODS_SCHEMA_OVERRIDE` env var. This will always be the first selected source for OED Schema if set.

The old behaviour was also broken since #225 — the `OEDVersion` column is now read from exposure files before `from_oed_schema_info` is called, so `None` was rarely reached in practice.

## Changes

- **`oed_schema.py`**: Remove DEV try/except. Add `ODS_SCHEMA_OVERRIDE` env var checked at the top of `from_oed_schema_info`, above all other sources including `OEDVersion` column and `"latest version"`.
- **`build.yml`**: Add `has_dev_spec` output signalling whether a dev OED spec was baked into the wheel.
- **`test.yml`**: When `has_dev_spec == 'true'`, set `ODS_SCHEMA_OVERRIDE` to the installed `DEVSpec.json` path — same testing behaviour as before, but explicit.

closes https://github.com/OasisLMF/ODS_Tools/issues/231
<!--end_release_notes-->
