### PR TITLE
enhance/fix_dev_schema

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ on:
       whl_filename:
         description: "Wheel Package filename"
         value: ${{ jobs.build.outputs.whl_filename }}
+      has_dev_spec:
+        description: "Whether a dev OED spec was baked into the wheel"
+        value: ${{ jobs.build.outputs.has_dev_spec }}
 
 jobs:
   oed_spec:
@@ -44,6 +47,7 @@ jobs:
     outputs:
       src_filename: ${{ steps.build_package.outputs.source }}
       whl_filename: ${{ steps.build_package.outputs.wheel }}
+      has_dev_spec: ${{ steps.build_package.outputs.has_dev_spec }}
 
     steps:
     - name: Github context
@@ -103,6 +107,7 @@ jobs:
         SRC=$(find ./dist/ -name "*.tar.gz"  -exec basename {} \;)
         echo "wheel=$WHL" >> $GITHUB_OUTPUT
         echo "source=$SRC" >> $GITHUB_OUTPUT
+        echo "has_dev_spec=${{ inputs.oed_spec_branch != '' || inputs.oed_spec_json != '' }}" >> $GITHUB_OUTPUT
 
     - name: Store source package
       uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,11 @@ jobs:
     - name: Activate dev OED spec
       if: needs.build-ods.outputs.has_dev_spec == 'true'
       run: |
-        DEV_SPEC=$(python -c "import ods_tools, os; print(os.path.join(os.path.dirname(ods_tools.__file__), 'data', 'OpenExposureData_DEVSpec.json'))")
+        DEV_SPEC=$(python -c "
+        import sys; sys.path = [p for p in sys.path if p]
+        import ods_tools, os
+        print(os.path.join(os.path.dirname(ods_tools.__file__), 'data', 'OpenExposureData_DEVSpec.json'))
+        ")
         echo "ODS_SCHEMA_OVERRIDE=$DEV_SPEC" >> $GITHUB_ENV
 
     - name: Install test deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,12 @@ jobs:
         pip install ${{ needs.build-odm.outputs.whl_filename }}
         pip install ${{ needs.build-ods.outputs.whl_filename }}
 
+    - name: Activate dev OED spec
+      if: needs.build-ods.outputs.has_dev_spec == 'true'
+      run: |
+        DEV_SPEC=$(python -c "import ods_tools, os; print(os.path.join(os.path.dirname(ods_tools.__file__), 'data', 'OpenExposureData_DEVSpec.json'))")
+        echo "ODS_SCHEMA_OVERRIDE=$DEV_SPEC" >> $GITHUB_ENV
+
     - name: Install test deps
       run: pip install -r tests/requirements.in
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,15 +57,16 @@ jobs:
         pip install ${{ needs.build-odm.outputs.whl_filename }}
         pip install ${{ needs.build-ods.outputs.whl_filename }}
 
+    - name: Download OED spec (if dev spec was built)
+      if: needs.build-ods.outputs.has_dev_spec == 'true'
+      uses: actions/download-artifact@v4
+      with:
+        name: extracted_spec
+        path: ${{ github.workspace }}/
+
     - name: Activate dev OED spec
       if: needs.build-ods.outputs.has_dev_spec == 'true'
-      run: |
-        DEV_SPEC=$(python -c "
-        import sys; sys.path = [p for p in sys.path if p]
-        import ods_tools, os
-        print(os.path.join(os.path.dirname(ods_tools.__file__), 'data', 'OpenExposureData_DEVSpec.json'))
-        ")
-        echo "ODS_SCHEMA_OVERRIDE=$DEV_SPEC" >> $GITHUB_ENV
+      run: echo "ODS_SCHEMA_OVERRIDE=${{ github.workspace }}/OpenExposureData_Spec.json" >> $GITHUB_ENV
 
     - name: Install test deps
       run: pip install -r tests/requirements.in

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -94,13 +94,8 @@ class OedSchema:
             OedSchema
         """
         if oed_schema_info is None or oed_schema_info == "":
-            try:
-                dev_schema_path = cls.DEFAULT_ODS_SCHEMA_PATH.format('DEV')
-                logger.debug(f"attempting to load DEV schema {dev_schema_path}")
-                return cls.from_json(dev_schema_path)
-            except FileNotFoundError as e:
-                logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
-                return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))
+            logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
+            return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))
         if isinstance(oed_schema_info, str):
             if oed_schema_info == "latest version":
                 oed_spec_files = glob(cls.DEFAULT_ODS_SCHEMA_PATH.format('*'))

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -15,6 +15,7 @@ OED_VERSION = '5.0.0'
 logger = logging.getLogger(__name__)
 
 ENV_ODS_SCHEMA_PATH = os.getenv('ODS_SCHEMA_PATH')
+ENV_ODS_SCHEMA_OVERRIDE = os.getenv('ODS_SCHEMA_OVERRIDE')
 
 
 # function to check if a subperil is part of a peril
@@ -93,6 +94,9 @@ class OedSchema:
         Returns:
             OedSchema
         """
+        if ENV_ODS_SCHEMA_OVERRIDE:
+            logger.debug(f"loading schema override: {ENV_ODS_SCHEMA_OVERRIDE}")
+            return cls.from_json(ENV_ODS_SCHEMA_OVERRIDE)
         if oed_schema_info is None or oed_schema_info == "":
             logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
             return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -15,7 +15,6 @@ OED_VERSION = '5.0.0'
 logger = logging.getLogger(__name__)
 
 ENV_ODS_SCHEMA_PATH = os.getenv('ODS_SCHEMA_PATH')
-ENV_ODS_SCHEMA_OVERRIDE = os.getenv('ODS_SCHEMA_OVERRIDE')
 
 
 # function to check if a subperil is part of a peril
@@ -94,9 +93,10 @@ class OedSchema:
         Returns:
             OedSchema
         """
-        if ENV_ODS_SCHEMA_OVERRIDE:
-            logger.debug(f"loading schema override: {ENV_ODS_SCHEMA_OVERRIDE}")
-            return cls.from_json(ENV_ODS_SCHEMA_OVERRIDE)
+        schema_override = os.getenv('ODS_SCHEMA_OVERRIDE')
+        if schema_override:
+            logger.debug(f"loading schema override: {schema_override}")
+            return cls.from_json(schema_override)
         if oed_schema_info is None or oed_schema_info == "":
             logger.debug(f"loading default schema {cls.DEFAULT_ODS_SCHEMA_PATH}")
             return cls.from_json(cls.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION))

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -14,6 +14,7 @@ import sys
 import pandas as pd
 import numpy as np
 from unittest import TestCase
+from unittest.mock import patch
 import tempfile
 
 # WORKAROUND - this line to to force an import from the installed ods_tools package
@@ -523,34 +524,36 @@ class OdsPackageTests(TestCase):
         self.assertTrue(exposure.location.dataframe['StreetAddress'][0] == 'Ô, Avenue des Champs-Élysées')
 
     def test_aliases_columns(self):
-        location_df = pd.DataFrame({
-            'PortNumber': [1, 1],
-            'AccNumber': [1, 2],
-            'LocNumberAlias': [1, 2],
-            'CountryCode': ['GB', 'FR'],
-            'LocPerilsCovered': 'WTC',
-            'BuildingTIV': ['1000', '20000'],
-            'ContentsTIV': [0, 0],
-            'LocCurrency': ['GBP', 'EUR']})
-        with tempfile.TemporaryDirectory() as tmp_run_dir:
-            # create a custom schema to init the test
-            custom_schema_path = pathlib.Path(tmp_run_dir, 'custom_schema.json')
-            with (open(OedSchema.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION)) as default_schema_file,
-                  open(custom_schema_path, 'w') as custom_schema_file):
-                default_schema = json.load(default_schema_file)
-                default_schema['input_fields']['Loc']['locnumber']['alias'] = 'LocNumberAlias'
-                json.dump(default_schema, custom_schema_file)
+        with patch.dict(os.environ):
+            os.environ.pop('ODS_SCHEMA_OVERRIDE', None)
+            location_df = pd.DataFrame({
+                'PortNumber': [1, 1],
+                'AccNumber': [1, 2],
+                'LocNumberAlias': [1, 2],
+                'CountryCode': ['GB', 'FR'],
+                'LocPerilsCovered': 'WTC',
+                'BuildingTIV': ['1000', '20000'],
+                'ContentsTIV': [0, 0],
+                'LocCurrency': ['GBP', 'EUR']})
+            with tempfile.TemporaryDirectory() as tmp_run_dir:
+                # create a custom schema to init the test
+                custom_schema_path = pathlib.Path(tmp_run_dir, 'custom_schema.json')
+                with (open(OedSchema.DEFAULT_ODS_SCHEMA_PATH.format(OED_VERSION)) as default_schema_file,
+                      open(custom_schema_path, 'w') as custom_schema_file):
+                    default_schema = json.load(default_schema_file)
+                    default_schema['input_fields']['Loc']['locnumber']['alias'] = 'LocNumberAlias'
+                    json.dump(default_schema, custom_schema_file)
 
-            exposure = OedExposure(**{
-                'location': location_df,
-                'oed_schema_info': custom_schema_path,
-                'use_field': True,
-                'check_oed': True,
-                'backend_dtype': 'pa_dtype',
-            })
-            pd.testing.assert_series_equal(exposure.location.dataframe['LocNumber'].astype(str),
-                                           location_df['LocNumberAlias'].astype(str),
-                                           check_names=False)
+                exposure = OedExposure(**{
+                    'location': location_df,
+                    'oed_schema_info': custom_schema_path,
+                    'use_field': True,
+                    'check_oed': True,
+                    'backend_dtype': 'pa_dtype',
+                })
+                pd.testing.assert_series_equal(exposure.location.dataframe['LocNumber'].astype(str),
+                                               location_df['LocNumberAlias'].astype(str),
+                                               check_names=False)
 
     def test_load_exposure_from_different_directory(self):
         """
@@ -599,63 +602,65 @@ class OdsPackageTests(TestCase):
             assert (modified_exposure.ri_info.dataframe['RiskLevel'] == '').all()  # check it works for string
 
     def test_fill_empty(self):
-        oed_schema = OedSchema.from_oed_schema_info(None)
-        test_fields = {
-            'intvalue': {
-                'Input Field Name': 'IntValue',
-                'Type & Description': 'a single int column with default',
-                'Required Field': 'O',
-                'Data Type': 'int',
-                'Allow blanks?': 'YES',
-                'Default': '0',
-                'Valid value range': 'n/a',
-                'pd_dtype': 'Int32',
-                'pa_dtype': 'int32[pyarrow]',
-            },
-            'IntValueMultipleXX': {
-                'Input Field Name': 'IntValueMultipleXX',
-                'Type & Description': '',
-                'Required Field': 'O',
-                'Data Type': 'int',
-                'Allow blanks?': 'YES',
-                'Default': '0',
-                'Valid value range': 'n/a',
-                'pd_dtype': 'Int32',
-                'pa_dtype': 'int32[pyarrow]',
-            },
-            'StringValueMultipleXX': {
-                'Input Field Name': 'StringValueMultipleXX',
-                'Type & Description': '',
-                'Required Field': 'O',
-                'Data Type': 'nvarchar(50)',
-                'Allow blanks?': 'YES',
-                'Default': 'foobar',
-                'Valid value range': 'n/a',
-                'pd_dtype': 'category',
-                'pa_dtype': 'string[pyarrow]',
+        with patch.dict(os.environ):
+            os.environ.pop('ODS_SCHEMA_OVERRIDE', None)
+            oed_schema = OedSchema.from_oed_schema_info(None)
+            test_fields = {
+                'intvalue': {
+                    'Input Field Name': 'IntValue',
+                    'Type & Description': 'a single int column with default',
+                    'Required Field': 'O',
+                    'Data Type': 'int',
+                    'Allow blanks?': 'YES',
+                    'Default': '0',
+                    'Valid value range': 'n/a',
+                    'pd_dtype': 'Int32',
+                    'pa_dtype': 'int32[pyarrow]',
+                },
+                'IntValueMultipleXX': {
+                    'Input Field Name': 'IntValueMultipleXX',
+                    'Type & Description': '',
+                    'Required Field': 'O',
+                    'Data Type': 'int',
+                    'Allow blanks?': 'YES',
+                    'Default': '0',
+                    'Valid value range': 'n/a',
+                    'pd_dtype': 'Int32',
+                    'pa_dtype': 'int32[pyarrow]',
+                },
+                'StringValueMultipleXX': {
+                    'Input Field Name': 'StringValueMultipleXX',
+                    'Type & Description': '',
+                    'Required Field': 'O',
+                    'Data Type': 'nvarchar(50)',
+                    'Allow blanks?': 'YES',
+                    'Default': 'foobar',
+                    'Valid value range': 'n/a',
+                    'pd_dtype': 'category',
+                    'pa_dtype': 'string[pyarrow]',
+                }
             }
-        }
 
-        for field_name, field_info in test_fields.items():
-            oed_schema.schema['input_fields']['Loc'][field_name.lower()] = field_info
+            for field_name, field_info in test_fields.items():
+                oed_schema.schema['input_fields']['Loc'][field_name.lower()] = field_info
 
-        loc_df = pd.DataFrame({
-            'PortNumber': [1, 1, 1, 1],
-            'AccNumber': [1, 1, 1, 1],
-            'LocNumber': [1, 2, 3, 4],
-            'CountryCode': ['UK', 'UK', 'UK', 'UK', ],
-            'LocPerilsCovered': ['WW2', 'WTC;WSS', 'QQ1;WW2', 'WTC'],
-            'BuildingTIV': ['1', '1', '1', '1'],
-            'ContentsTIV': ['1', '1', '1', '1'],
-            'LocCurrency': ['GBP', 'GBP', 'GBP', 'GBP'],
-            'intvalue': [1, '2', '', ''],
-            'IntValueMultiple1': [1, '2', '', ''],
-            'StringValueMultiple01': [1, '2', '', ''],
-        })
-        oed = OedExposure(**{'location': loc_df, 'use_field': True, 'oed_schema_info': oed_schema})
-        assert oed.location.dataframe['IntValue'].to_list() == [1, 2, 0, 0]
-        assert oed.location.dataframe['IntValueMultiple1'].to_list() == [1, 2, 0, 0]
-        assert oed.location.dataframe['StringValueMultiple01'].to_list() == ['1', '2', 'foobar', 'foobar']
+            loc_df = pd.DataFrame({
+                'PortNumber': [1, 1, 1, 1],
+                'AccNumber': [1, 1, 1, 1],
+                'LocNumber': [1, 2, 3, 4],
+                'CountryCode': ['UK', 'UK', 'UK', 'UK', ],
+                'LocPerilsCovered': ['WW2', 'WTC;WSS', 'QQ1;WW2', 'WTC'],
+                'BuildingTIV': ['1', '1', '1', '1'],
+                'ContentsTIV': ['1', '1', '1', '1'],
+                'LocCurrency': ['GBP', 'GBP', 'GBP', 'GBP'],
+                'intvalue': [1, '2', '', ''],
+                'IntValueMultiple1': [1, '2', '', ''],
+                'StringValueMultiple01': [1, '2', '', ''],
+            })
+            oed = OedExposure(**{'location': loc_df, 'use_field': True, 'oed_schema_info': oed_schema})
+            assert oed.location.dataframe['IntValue'].to_list() == [1, 2, 0, 0]
+            assert oed.location.dataframe['IntValueMultiple1'].to_list() == [1, 2, 0, 0]
+            assert oed.location.dataframe['StringValueMultiple01'].to_list() == ['1', '2', 'foobar', 'foobar']
 
     def test_relative_and_absolute_path(self):
         original_cwd = os.getcwd()
@@ -1241,48 +1246,50 @@ class OdsPackageTests(TestCase):
         import pyarrow as pa
         from ods_tools.oed.common import pa_dict_encode
 
-        oed_schema = OedSchema.from_oed_schema_info(None)
-        custom_field = {
-            'Input Field Name': 'CustomStatus',
-            'Type & Description': 'custom string field for test',
-            'Required Field': 'O',
-            'Data Type': 'nvarchar(10)',
-            'Allow blanks?': 'YES',
-            'Default': 'OPEN',
-            'Valid value range': 'n/a',
-            'pd_dtype': 'category',
-            'pa_dtype': 'string[pyarrow]',
-            'File Name': 'Loc',
-        }
-        oed_schema.schema['input_fields']['Loc']['customstatus'] = custom_field
-        oed_schema.schema.setdefault('cr_field', {}).setdefault('Loc', {})['CustomStatus'] = ['CustomStatus']
+        with patch.dict(os.environ):
+            os.environ.pop('ODS_SCHEMA_OVERRIDE', None)
+            oed_schema = OedSchema.from_oed_schema_info(None)
+            custom_field = {
+                'Input Field Name': 'CustomStatus',
+                'Type & Description': 'custom string field for test',
+                'Required Field': 'O',
+                'Data Type': 'nvarchar(10)',
+                'Allow blanks?': 'YES',
+                'Default': 'OPEN',
+                'Valid value range': 'n/a',
+                'pd_dtype': 'category',
+                'pa_dtype': 'string[pyarrow]',
+                'File Name': 'Loc',
+            }
+            oed_schema.schema['input_fields']['Loc']['customstatus'] = custom_field
+            oed_schema.schema.setdefault('cr_field', {}).setdefault('Loc', {})['CustomStatus'] = ['CustomStatus']
 
-        loc_df = pd.DataFrame({
-            'PortNumber': ['1', '1'],
-            'AccNumber': ['A1', 'A1'],
-            'LocNumber': ['L1', 'L2'],
-            'CountryCode': ['GB', 'GB'],
-            'LocPerilsCovered': ['WTC', 'WTC'],
-            'BuildingTIV': [1000.0, 2000.0],
-            'ContentsTIV': [0.0, 0.0],
-            'LocCurrency': ['GBP', 'GBP'],
-            'CustomStatus': ['OPEN', 'OPEN'],
-        })
-        exposure = OedExposure(location=loc_df, use_field=True, oed_schema_info=oed_schema, backend_dtype='pa_dtype')
+            loc_df = pd.DataFrame({
+                'PortNumber': ['1', '1'],
+                'AccNumber': ['A1', 'A1'],
+                'LocNumber': ['L1', 'L2'],
+                'CountryCode': ['GB', 'GB'],
+                'LocPerilsCovered': ['WTC', 'WTC'],
+                'BuildingTIV': [1000.0, 2000.0],
+                'ContentsTIV': [0.0, 0.0],
+                'LocCurrency': ['GBP', 'GBP'],
+                'CustomStatus': ['OPEN', 'OPEN'],
+            })
+            exposure = OedExposure(location=loc_df, use_field=True, oed_schema_info=oed_schema, backend_dtype='pa_dtype')
 
-        encoded = pa_dict_encode(exposure.location.dataframe['CustomStatus'].astype('string[pyarrow]'))
-        if encoded is not None:
-            exposure.location.dataframe['CustomStatus'] = encoded
+            encoded = pa_dict_encode(exposure.location.dataframe['CustomStatus'].astype('string[pyarrow]'))
+            if encoded is not None:
+                exposure.location.dataframe['CustomStatus'] = encoded
 
-        cs_dtype = exposure.location.dataframe['CustomStatus'].dtype
-        self.assertTrue(
-            isinstance(cs_dtype, pd.ArrowDtype) and pa.types.is_dictionary(cs_dtype.pyarrow_dtype),
-            f"Expected CustomStatus to be dict-encoded, got {cs_dtype}",
-        )
-        try:
-            exposure.check()
-        except TypeError as e:
-            self.fail(f"check_conditional_requirement raised TypeError on dict-encoded string column: {e}")
+            cs_dtype = exposure.location.dataframe['CustomStatus'].dtype
+            self.assertTrue(
+                isinstance(cs_dtype, pd.ArrowDtype) and pa.types.is_dictionary(cs_dtype.pyarrow_dtype),
+                f"Expected CustomStatus to be dict-encoded, got {cs_dtype}",
+            )
+            try:
+                exposure.check()
+            except TypeError as e:
+                self.fail(f"check_conditional_requirement raised TypeError on dict-encoded string column: {e}")
 
 
 class PaDictEncodeTests(TestCase):


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### enhance/fix_dev_schema

Removes the implicit `DEVSpec.json` auto-load from `from_oed_schema_info(None)` (issue #231) and replaces it with an explicit `ODS_SCHEMA_OVERRIDE` env var. This will always be the first selected source for OED Schema if set.

The old behaviour was also broken since #225 — the `OEDVersion` column is now read from exposure files before `from_oed_schema_info` is called, so `None` was rarely reached in practice.

## Changes

- **`oed_schema.py`**: Remove DEV try/except. Add `ODS_SCHEMA_OVERRIDE` env var checked at the top of `from_oed_schema_info`, above all other sources including `OEDVersion` column and `"latest version"`.
- **`build.yml`**: Add `has_dev_spec` output signalling whether a dev OED spec was baked into the wheel.
- **`test.yml`**: When `has_dev_spec == 'true'`, set `ODS_SCHEMA_OVERRIDE` to the installed `DEVSpec.json` path — same testing behaviour as before, but explicit.

closes https://github.com/OasisLMF/ODS_Tools/issues/231
<!--end_release_notes-->

