### PR TITLE
enhance/supported_oed_versions

### DIFF
--- a/ods_tools/oed/exposure.py
+++ b/ods_tools/oed/exposure.py
@@ -51,7 +51,9 @@ class OedExposure:
                  portfolio_numbers=None,
                  base_df_engine=None,
                  exposure_df_engine=None,
-                 backend_dtype=None, **kwargs):
+                 backend_dtype=None,
+                 supported_oed_versions=None,
+                 disable_oed_version_update=False, **kwargs):
         """
         Create an OED object,
         each input can be the object itself or  information that will be used to create the object
@@ -174,6 +176,24 @@ class OedExposure:
             self.working_dir = Path('.').absolute()
         else:
             self.working_dir = working_dir
+
+        if supported_oed_versions:
+            if isinstance(supported_oed_versions, str):
+                supported_oed_versions = [supported_oed_versions]
+            if isinstance(supported_oed_versions, list):
+                for v in supported_oed_versions:
+                    try:
+                        OedSchema.from_oed_schema_info(v)
+                    except (ValueError, OdsException) as e:
+                        raise OdsException(f"supported_oed_versions contains invalid version '{v}': {e}") from e
+                if not disable_oed_version_update:
+                    target = max(supported_oed_versions, key=version.parse)
+                    logger.info(f"Converting to OED version {target}")
+                    self.to_version(target)
+            else:
+                logger.warning(f"Invalid OED version information in model settings: {supported_oed_versions}")
+        else:
+            logger.debug("No supported OED version information in model settings.")
 
         if check_oed:
             self.check()

--- a/ods_tools/oed/exposure.py
+++ b/ods_tools/oed/exposure.py
@@ -75,6 +75,12 @@ class OedExposure:
             base_df_engine (Union[str, InputReaderConfig]): The default engine to use when loading dataframes
             exposure_df_engine (Union[str, InputReaderConfig]):
                 The exposure specific engine to use when loading dataframes
+            supported_oed_versions (list[str], None): A list of OED version strings this model supports
+                (from model_settings.json data_settings). When set and disable_oed_version_update is False,
+                the exposure is converted to the highest supported version via to_version(). Accepts both
+                2-part ("3.4") and 3-part ("3.4.1") version strings.
+            disable_oed_version_update (bool): If True, skip the to_version() conversion even when
+                supported_oed_versions is set.
         """
         self.use_field = use_field
 
@@ -183,12 +189,11 @@ class OedExposure:
             if isinstance(supported_oed_versions, list):
                 for v in supported_oed_versions:
                     try:
-                        OedSchema.from_oed_schema_info(v)
-                    except (ValueError, OdsException) as e:
+                        version.parse(v)
+                    except version.InvalidVersion as e:
                         raise OdsException(f"supported_oed_versions contains invalid version '{v}': {e}") from e
                 if not disable_oed_version_update:
                     target = max(supported_oed_versions, key=version.parse)
-                    logger.info(f"Converting to OED version {target}")
                     self.to_version(target)
             else:
                 logger.warning(f"Invalid OED version information in model settings: {supported_oed_versions}")
@@ -556,12 +561,18 @@ class OedExposure:
 
     def to_version(self, to_version):
         """
-        goes through location to convert columns to specific version.
-        Right now it works for OccupancyCode and ConstructionCode.
-        (please note that it only supports minor version changes in "major.minor" format, e.g. 3.2, 7.4, etc.)
+        Convert OccupancyCode and ConstructionCode values in the location dataframe to be
+        compatible with an older OED version by applying versioning fallback rules from the
+        loaded schema.
+
+        Only affects columns present in the location file. Only OccupancyCode and ConstructionCode
+        are currently handled. The target version is stripped to major.minor before comparison,
+        so "3.4.1" and "3.4.0" behave identically. Versioning rules for versions strictly newer
+        than the target are applied in descending order.
 
         Args:
-            version (str): specific version to roll to
+            to_version (str): target OED version string (e.g. "3.4", "3.4.1"). Codes introduced
+                in OED versions newer than this target will be replaced with their fallback values.
 
         Returns:
             itself (OedExposure): updated object
@@ -576,7 +587,8 @@ class OedExposure:
         except version.InvalidVersion:
             raise ValueError(f"Invalid version: {to_version}")
 
-        # Select which conversions to apply
+        # Select which conversions to apply: versioning keys represent the last OED version
+        # *without* those codes, so keys >= target mean codes introduced after the target.
         conversions = sorted(
             [
                 ver
@@ -586,6 +598,11 @@ class OedExposure:
             key=lambda x: version.parse(x),
             reverse=True,
         )
+
+        if conversions:
+            logger.info(f"Converting to OED version {to_version} — applying fallbacks for: {conversions}")
+        else:
+            logger.debug(f"to_version({to_version!r}): no versioning rules apply, no changes made")
 
         # Check for the existence of OccupancyCode and ConstructionCode columns
         has_occupancy_code = "OccupancyCode" in self.location.dataframe.columns

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -81,6 +81,13 @@ class OedSchema:
         """
         return self.json_path
 
+    @cached_property
+    def version(self):
+        """OED spec version parsed from json_path, or None for custom schemas."""
+        version_pattern = re.compile(r"OpenExposureData_(\d+\.\d+\.\d+)Spec\.json")
+        m = version_pattern.search(str(self.json_path))
+        return m.group(1) if m else None
+
     @classmethod
     def from_oed_schema_info(cls, oed_schema_info):
         """

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -81,13 +81,6 @@ class OedSchema:
         """
         return self.json_path
 
-    @cached_property
-    def version(self):
-        """OED spec version parsed from json_path, or None for custom schemas."""
-        version_pattern = re.compile(r"OpenExposureData_(\d+\.\d+\.\d+)Spec\.json")
-        m = version_pattern.search(str(self.json_path))
-        return m.group(1) if m else None
-
     @classmethod
     def from_oed_schema_info(cls, oed_schema_info):
         """

--- a/ods_tools/oed/oed_schema.py
+++ b/ods_tools/oed/oed_schema.py
@@ -112,7 +112,7 @@ class OedSchema:
             if oed_schema_info == "latest version":
                 oed_spec_files = glob(cls.DEFAULT_ODS_SCHEMA_PATH.format('*'))
 
-                version_pattern = re.compile("OpenExposureData_(\\d+\\.\\d+\\.\\d+)Spec\.json")
+                version_pattern = re.compile("OpenExposureData_(\\d+\\.\\d+\\.\\d+)Spec\\.json")
                 versions = [version_pattern.search(path).group(1) for path in oed_spec_files if version_pattern.search(path)]
 
                 try:

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -1000,6 +1000,39 @@ class OdsPackageTests(TestCase):
         # # Assert the OccupancyCode is as expected
         assert oed_exposure.location.dataframe.loc[0, "OccupancyCode"] == 9995
 
+    def test_supported_oed_versions_calls_to_version(self):
+        from unittest.mock import patch
+        with patch.object(OedExposure, 'to_version') as mock_to_version:
+            OedExposure(
+                location=self.tmp_dir_path / "SourceLocOEDPiWind.csv",
+                account=self.tmp_dir_path / "SourceAccOEDPiWind.csv",
+                use_field=True,
+                supported_oed_versions=["3.4.1", "4.0.0"],
+            )
+            mock_to_version.assert_called_once_with("4.0.0")
+
+    def test_supported_oed_versions_disable_update(self):
+        from unittest.mock import patch
+        with patch.object(OedExposure, 'to_version') as mock_to_version:
+            OedExposure(
+                location=self.tmp_dir_path / "SourceLocOEDPiWind.csv",
+                account=self.tmp_dir_path / "SourceAccOEDPiWind.csv",
+                use_field=True,
+                supported_oed_versions=["3.4.1", "4.0.0"],
+                disable_oed_version_update=True,
+            )
+            mock_to_version.assert_not_called()
+
+    def test_supported_oed_versions_invalid_version_raises(self):
+        from ods_tools.oed.common import OdsException
+        with self.assertRaises(OdsException):
+            OedExposure(
+                location=self.tmp_dir_path / "SourceLocOEDPiWind.csv",
+                account=self.tmp_dir_path / "SourceAccOEDPiWind.csv",
+                use_field=True,
+                supported_oed_versions=["99.99.99"],
+            )
+
     def test_probe_oedversion_from_oedsource(self):
         exposure = OedExposure(
             location=self.tmp_dir_path / "SourceLocOEDPiWind.csv",

--- a/tests/test_ods_package.py
+++ b/tests/test_ods_package.py
@@ -1030,7 +1030,7 @@ class OdsPackageTests(TestCase):
                 location=self.tmp_dir_path / "SourceLocOEDPiWind.csv",
                 account=self.tmp_dir_path / "SourceAccOEDPiWind.csv",
                 use_field=True,
-                supported_oed_versions=["99.99.99"],
+                supported_oed_versions=["not-a-version"],
             )
 
     def test_probe_oedversion_from_oedsource(self):


### PR DESCRIPTION
<!--- IMPORTANT: Please attach or create an issue submitting a Pull Request. -->                                                                               

<!-- REVIEW: to merge this PR you need to choose at least 2 reviewers, such that:
 - at least one reviewer is an expert of the specific code/module that is being modified.
 - at least one reviewer does a quantitative/detailed review of the changes, i.e., fully understands the changes.
 - at least one reviewer checks that the code follows the guidelines in CONTRIBUTING.md (see link to the right of this page).
Note: it doesn't matter how these three aspects are split among the two reviewers, but it is important they are all fulfilled.
 -->

<!--start_release_notes-->
### enhance/supported_oed_versions
Move `supported_oed_versions` handling into `OedExposure`

Adds `supported_oed_versions` and `disable_oed_version_update` parameters to `OedExposure.__init__()`, so exposure version conversion happens at construction time for every code path — not just key generation.

Validates each version string with `version.parse()` (accepts both 2-part `"3.4"` and 3-part `"3.4.1"` formats)
Calls `to_version(max(supported_oed_versions))` unless `disable_oed_version_update=True`
Updates `to_version` docstring to accurately describe its behaviour and current limitations
Fixes a pre-existing invalid escape sequence in `oed_schema.py`
Adds 3 tests: conversion called, conversion disabled, invalid version raises

closes https://github.com/OasisLMF/ODS_Tools/issues/230
<!--end_release_notes-->
