### PR TITLE
Fix ODTF transformer callbacks with parser self argument

### DIFF
--- a/ods_tools/odtf/transformers/transform.py
+++ b/ods_tools/odtf/transformers/transform.py
@@ -133,6 +133,8 @@ def create_transformer_class(row, transformer_mapping):
     :return: The new transformer class
     """
     def mapped_function(name, *args, **kwargs):
+        if args and args[0].__class__.__name__ == "TreeTransformer":
+            args = args[1:]
         return transformer_mapping[name](row, *args, **kwargs)
 
     @v_args(inline=True)

--- a/ods_tools/odtf/transformers/transform_utils.py
+++ b/ods_tools/odtf/transformers/transform_utils.py
@@ -198,7 +198,9 @@ def replace_double(row, first_column, second_column, *triplets):
     return first_column
 
 
-def safe_lookup(r, name):
+def safe_lookup(r, name, *extra):
+    if extra:
+        name = extra[-1]
     if isinstance(name, Token):
         name = name.value
     if name == 'True':


### PR DESCRIPTION
## Summary
- allow ODTF lookup callbacks to ignore extra parser arguments
- drop the TreeTransformer self argument before dispatching mapped functions
- fixes core CSV ODTF transformations under Python 3.14 / current parser behavior

## Validation
Ran focused ODTF validation through my evidence runner:

- `tests/test_odtf.py::test_transformation_as_expected` -> passed
- `tests/test_odtf.py::test_simple_transform_to_csv[simple_transform_csv]` -> passed
- `tests/test_odtf.py::test_simple_transform_no_config` -> passed

Command:
```bash
uv run --with-requirements requirements.in --with pytest --with pyyaml --with lark python -m pytest -v tests/test_odtf.py::test_transformation_as_expected 'tests/test_odtf.py::test_simple_transform_to_csv[simple_transform_csv]' tests/test_odtf.py::test_simple_transform_no_config
```

Note:
Full sqlite/db ODTF paths were not included in this focused validation because this local environment does not include pyodbc.